### PR TITLE
Support for comparing objects with boolean type in `isLike` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The `unknownutil` provides the following predicate functions
 
 - `isString(x: unknown): x is string`
 - `isNumber(x: unknown): x is number`
+- `isBoolean(x: unknown): x is boolean`
 - `isArray<T extends unknown>(x: unknown, pred?: Predicate<T>): x is T[]`
 - `isObject<T extends unknown>(x: unknown, pred?: Predicate<T>): x is Record<string, T>`
 - `isFunction(x: unknown): x is (...args: unknown[]) => unknown`
@@ -93,6 +94,7 @@ The `unknownutil` provides the following ensure functions which will raise
 
 - `ensureString(x: unknown): assert x is string`
 - `ensureNumber(x: unknown): assert x is string`
+- `ensureBoolean(x: unknown): assert x is boolean`
 - `ensureArray<T extends unknown>(x: unknown, pred?: Predicate<T>): assert x is T[]`
 - `ensureObject<T extends unknown>(x: unknown, pred?: Predicate<T>): x ensure Record<string, T>`
 - `ensureFunction(x: unknown): x ensure (...args: unknown[]) => unknown`

--- a/ensure.ts
+++ b/ensure.ts
@@ -1,5 +1,6 @@
 import {
   isArray,
+  isBoolean,
   isFunction,
   isLike,
   isNone,
@@ -48,6 +49,13 @@ export function ensureString(x: unknown): asserts x is string {
  */
 export function ensureNumber(x: unknown): asserts x is number {
   return ensure(x, isNumber, "The value must be number");
+}
+
+/**
+ * Ensure if `x` is boolean by raising an `EnsureError` when it's not.
+ */
+export function ensureBoolean(x: unknown): asserts x is boolean {
+  return ensure(x, isBoolean, "The value must be boolean");
 }
 
 /**

--- a/ensure_test.ts
+++ b/ensure_test.ts
@@ -2,6 +2,7 @@ import { assertThrows } from "./deps_test.ts";
 import {
   ensure,
   ensureArray,
+  ensureBoolean,
   ensureFunction,
   ensureLike,
   ensureNone,
@@ -11,7 +12,7 @@ import {
   ensureString,
   ensureUndefined,
 } from "./ensure.ts";
-import { isNumber, isString } from "./is.ts";
+import { isBoolean, isNumber, isString } from "./is.ts";
 
 Deno.test("ensure does nothing when pred return true", () => {
   ensure("a", isString);
@@ -27,6 +28,8 @@ Deno.test("ensureString does nothing on string", () => {
 });
 Deno.test("ensureString throws error on non string", () => {
   assertThrows(() => ensureString(0));
+  assertThrows(() => ensureString(true));
+  assertThrows(() => ensureString(false));
   assertThrows(() => ensureString([]));
   assertThrows(() => ensureString({}));
   assertThrows(() => ensureString(function () {}));
@@ -41,11 +44,27 @@ Deno.test("ensureNumber does nothing on number", () => {
 });
 Deno.test("ensureNumber throws error on non number", () => {
   assertThrows(() => ensureNumber("a"));
+  assertThrows(() => ensureNumber(true));
+  assertThrows(() => ensureNumber(false));
   assertThrows(() => ensureNumber([]));
   assertThrows(() => ensureNumber({}));
   assertThrows(() => ensureNumber(function () {}));
   assertThrows(() => ensureNumber(undefined));
   assertThrows(() => ensureNumber(null));
+});
+
+Deno.test("ensureBoolean does nothing on boolean", () => {
+  ensureBoolean(true);
+  ensureBoolean(false);
+});
+Deno.test("ensureBoolean throws error on non boolean", () => {
+  assertThrows(() => ensureBoolean(0));
+  assertThrows(() => ensureBoolean("a"));
+  assertThrows(() => ensureBoolean([]));
+  assertThrows(() => ensureBoolean({}));
+  assertThrows(() => ensureBoolean(function () {}));
+  assertThrows(() => ensureBoolean(undefined));
+  assertThrows(() => ensureBoolean(null));
 });
 
 Deno.test("ensureArray does nothing on array", () => {
@@ -56,6 +75,8 @@ Deno.test("ensureArray does nothing on array", () => {
 Deno.test("ensureArray throws error on non array", () => {
   assertThrows(() => ensureArray("a"));
   assertThrows(() => ensureArray(0));
+  assertThrows(() => ensureArray(true));
+  assertThrows(() => ensureArray(false));
   assertThrows(() => ensureArray({}));
   assertThrows(() => ensureArray(function () {}));
   assertThrows(() => ensureArray(undefined));
@@ -64,10 +85,12 @@ Deno.test("ensureArray throws error on non array", () => {
 Deno.test("ensureArray<T> does nothing on T array", () => {
   ensureArray([0, 1, 2], isNumber);
   ensureArray(["a", "b", "c"], isString);
+  ensureArray([true, false, true], isBoolean);
 });
 Deno.test("ensureArray<T> throws error on non T array", () => {
   assertThrows(() => ensureArray([0, 1, 2], isString));
   assertThrows(() => ensureArray(["a", "b", "c"], isNumber));
+  assertThrows(() => ensureArray([true, false, true], isString));
 });
 
 Deno.test("ensureObject does nothing on object", () => {
@@ -78,6 +101,8 @@ Deno.test("ensureObject does nothing on object", () => {
 Deno.test("ensureObject throws error on non object", () => {
   assertThrows(() => ensureObject("a"));
   assertThrows(() => ensureObject(0));
+  assertThrows(() => ensureObject(true));
+  assertThrows(() => ensureObject(false));
   assertThrows(() => ensureObject([]));
   assertThrows(() => ensureObject(function () {}));
   assertThrows(() => ensureObject(undefined));
@@ -86,10 +111,12 @@ Deno.test("ensureObject throws error on non object", () => {
 Deno.test("ensureObject<T> does nothing on T object", () => {
   ensureObject({ a: 0 }, isNumber);
   ensureObject({ a: "a" }, isString);
+  ensureObject({ a: true }, isBoolean);
 });
 Deno.test("ensureObject<T> throws error on non T object", () => {
   assertThrows(() => ensureObject({ a: 0 }, isString));
   assertThrows(() => ensureObject({ a: "a" }, isNumber));
+  assertThrows(() => ensureObject({ a: true }, isString));
 });
 
 Deno.test("ensureFunction does nothing on function", () => {
@@ -101,6 +128,8 @@ Deno.test("ensureFunction does nothing on function", () => {
 Deno.test("ensureFunction throws error on non function", () => {
   assertThrows(() => ensureFunction("a"));
   assertThrows(() => ensureFunction(0));
+  assertThrows(() => ensureFunction(true));
+  assertThrows(() => ensureFunction(false));
   assertThrows(() => ensureFunction([]));
   assertThrows(() => ensureFunction({}));
   assertThrows(() => ensureFunction(undefined));
@@ -113,6 +142,8 @@ Deno.test("ensureNull does nothing on null", () => {
 Deno.test("ensureNull throws error on non null", () => {
   assertThrows(() => ensureNull("a"));
   assertThrows(() => ensureNull(0));
+  assertThrows(() => ensureNull(true));
+  assertThrows(() => ensureNull(false));
   assertThrows(() => ensureNull([]));
   assertThrows(() => ensureNull({}));
   assertThrows(() => ensureNull(function () {}));
@@ -125,6 +156,8 @@ Deno.test("ensureUndefined does nothing on undefined", () => {
 Deno.test("ensureUndefined throws error on non undefined", () => {
   assertThrows(() => ensureUndefined("a"));
   assertThrows(() => ensureUndefined(0));
+  assertThrows(() => ensureUndefined(true));
+  assertThrows(() => ensureUndefined(false));
   assertThrows(() => ensureUndefined([]));
   assertThrows(() => ensureUndefined({}));
   assertThrows(() => ensureUndefined(function () {}));
@@ -138,6 +171,8 @@ Deno.test("ensureNone does nothing on null or undefined", () => {
 Deno.test("ensureNone throws error on non null nor undefined", () => {
   assertThrows(() => ensureNone("a"));
   assertThrows(() => ensureNone(0));
+  assertThrows(() => ensureNone(true));
+  assertThrows(() => ensureNone(false));
   assertThrows(() => ensureNone([]));
   assertThrows(() => ensureNone({}));
   assertThrows(() => ensureNone(function () {}));
@@ -148,6 +183,8 @@ Deno.test("ensureLike does it's job on string", () => {
   ensureLike(ref, "Hello");
 
   assertThrows(() => ensureLike(ref, 0));
+  assertThrows(() => ensureLike(ref, true));
+  assertThrows(() => ensureLike(ref, false));
   assertThrows(() => ensureLike(ref, []));
   assertThrows(() => ensureLike(ref, {}));
   assertThrows(() => ensureLike(ref, function () {}));
@@ -161,6 +198,8 @@ Deno.test("ensureLike does it's job on number", () => {
   ensureLike(ref, 0.1);
 
   assertThrows(() => ensureLike(ref, "a"));
+  assertThrows(() => ensureLike(ref, true));
+  assertThrows(() => ensureLike(ref, false));
   assertThrows(() => ensureLike(ref, []));
   assertThrows(() => ensureLike(ref, {}));
   assertThrows(() => ensureLike(ref, function () {}));
@@ -184,9 +223,11 @@ Deno.test("ensureLike does it's job on T array", () => {
   const ref: unknown[] = [];
   ensureLike(ref, [0, 1, 2], isNumber);
   ensureLike(ref, ["a", "b", "c"], isString);
+  ensureLike(ref, [true, false, true], isBoolean);
 
   assertThrows(() => ensureLike(ref, [0, 1, 2], isString));
   assertThrows(() => ensureLike(ref, ["a", "b", "c"], isNumber));
+  assertThrows(() => ensureLike(ref, [true, false, true], isString));
 });
 Deno.test("ensureLike does it's job on tuple", () => {
   const ref = ["", 0, ""];
@@ -206,6 +247,8 @@ Deno.test("ensureLike does it's job on object", () => {
 
   assertThrows(() => ensureLike(ref, "a"));
   assertThrows(() => ensureLike(ref, 0));
+  assertThrows(() => ensureLike(ref, true));
+  assertThrows(() => ensureLike(ref, false));
   assertThrows(() => ensureLike(ref, []));
   assertThrows(() => ensureLike(ref, function () {}));
   assertThrows(() => ensureLike(ref, undefined));
@@ -215,9 +258,11 @@ Deno.test("ensureLike does it's job on T object", () => {
   const ref = {};
   ensureLike(ref, { a: 0 }, isNumber);
   ensureLike(ref, { a: "a" }, isString);
+  ensureLike(ref, { a: true }, isBoolean);
 
   assertThrows(() => ensureLike(ref, { a: 0 }, isString));
   assertThrows(() => ensureLike(ref, { a: "a" }, isNumber));
+  assertThrows(() => ensureLike(ref, { a: true }, isString));
 });
 Deno.test("ensureLike does it's job on struct", () => {
   const ref = { foo: "", bar: 0 };
@@ -237,6 +282,8 @@ Deno.test("ensureLike does it's job on function", () => {
 
   assertThrows(() => ensureLike(ref, "a"));
   assertThrows(() => ensureLike(ref, 0));
+  assertThrows(() => ensureLike(ref, true));
+  assertThrows(() => ensureLike(ref, false));
   assertThrows(() => ensureLike(ref, []));
   assertThrows(() => ensureLike(ref, {}));
   assertThrows(() => ensureLike(ref, undefined));
@@ -248,6 +295,8 @@ Deno.test("ensureLike does it's job on null", () => {
 
   assertThrows(() => ensureLike(ref, "a"));
   assertThrows(() => ensureLike(ref, 0));
+  assertThrows(() => ensureLike(ref, true));
+  assertThrows(() => ensureLike(ref, false));
   assertThrows(() => ensureLike(ref, []));
   assertThrows(() => ensureLike(ref, {}));
   assertThrows(() => ensureLike(ref, function () {}));
@@ -259,6 +308,8 @@ Deno.test("ensureLike does it's job on undefined", () => {
 
   assertThrows(() => ensureLike(ref, "a"));
   assertThrows(() => ensureLike(ref, 0));
+  assertThrows(() => ensureLike(ref, true));
+  assertThrows(() => ensureLike(ref, false));
   assertThrows(() => ensureLike(ref, []));
   assertThrows(() => ensureLike(ref, {}));
   assertThrows(() => ensureLike(ref, function () {}));

--- a/is.ts
+++ b/is.ts
@@ -15,6 +15,13 @@ export function isNumber(x: unknown): x is number {
 }
 
 /**
+ * Return true if the value is boolean
+ */
+export function isBoolean(x: unknown): x is boolean {
+  return typeof x === "boolean";
+}
+
+/**
  * Return true if the value is array
  */
 export function isArray<T extends unknown>(
@@ -79,6 +86,9 @@ export function isLike<R, T extends unknown>(
     return true;
   }
   if (isNumber(ref) && isNumber(x)) {
+    return true;
+  }
+  if (isBoolean(ref) && isBoolean(x)) {
     return true;
   }
   if (isArray(ref, pred) && isArray(x, pred)) {

--- a/is_test.ts
+++ b/is_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "./deps_test.ts";
 import {
   isArray,
+  isBoolean,
   isFunction,
   isLike,
   isNone,
@@ -17,6 +18,8 @@ Deno.test("isString returns true on array", () => {
 });
 Deno.test("isString returns false on non array", () => {
   assertEquals(isString(0), false);
+  assertEquals(isString(true), false);
+  assertEquals(isString(false), false);
   assertEquals(isString([]), false);
   assertEquals(isString({}), false);
   assertEquals(isString(function () {}), false);
@@ -30,11 +33,27 @@ Deno.test("isNumber returns true on array", () => {
 });
 Deno.test("isNumber returns false on non array", () => {
   assertEquals(isNumber(""), false);
+  assertEquals(isNumber(true), false);
+  assertEquals(isNumber(false), false);
   assertEquals(isNumber([]), false);
   assertEquals(isNumber({}), false);
   assertEquals(isNumber(function () {}), false);
   assertEquals(isNumber(null), false);
   assertEquals(isNumber(undefined), false);
+});
+
+Deno.test("isBoolean returns true on boolean", () => {
+  assertEquals(isBoolean(true), true);
+  assertEquals(isBoolean(false), true);
+});
+Deno.test("isBoolean returns false on non boolean", () => {
+  assertEquals(isBoolean(0), false);
+  assertEquals(isBoolean(""), false);
+  assertEquals(isBoolean([]), false);
+  assertEquals(isBoolean({}), false);
+  assertEquals(isBoolean(function () {}), false);
+  assertEquals(isBoolean(null), false);
+  assertEquals(isBoolean(undefined), false);
 });
 
 Deno.test("isArray returns true on array", () => {
@@ -46,6 +65,8 @@ Deno.test("isArray returns true on array", () => {
 Deno.test("isArray returns false on non array", () => {
   assertEquals(isArray(""), false);
   assertEquals(isArray(0), false);
+  assertEquals(isArray(true), false);
+  assertEquals(isArray(false), false);
   assertEquals(isArray({}), false);
   assertEquals(isArray(function () {}), false);
   assertEquals(isArray(null), false);
@@ -54,10 +75,12 @@ Deno.test("isArray returns false on non array", () => {
 Deno.test("isArray<T> returns true on T array", () => {
   assertEquals(isArray([0, 1, 2], isNumber), true);
   assertEquals(isArray(["a", "b", "c"], isString), true);
+  assertEquals(isArray([true, false, true], isBoolean), true);
 });
 Deno.test("isArray<T> returns false on non T array", () => {
   assertEquals(isArray([0, 1, 2], isString), false);
   assertEquals(isArray(["a", "b", "c"], isNumber), false);
+  assertEquals(isArray([true, false, true], isString), false);
 });
 
 Deno.test("isObject returns true on object", () => {
@@ -68,6 +91,8 @@ Deno.test("isObject returns true on object", () => {
 Deno.test("isObject returns false on non object", () => {
   assertEquals(isObject(""), false);
   assertEquals(isObject(0), false);
+  assertEquals(isObject(true), false);
+  assertEquals(isObject(false), false);
   assertEquals(isObject([]), false);
   assertEquals(isObject(function () {}), false);
   assertEquals(isObject(null), false);
@@ -76,10 +101,12 @@ Deno.test("isObject returns false on non object", () => {
 Deno.test("isObject<T> returns true on T object", () => {
   assertEquals(isObject({ a: 0 }, isNumber), true);
   assertEquals(isObject({ a: "a" }, isString), true);
+  assertEquals(isObject({ a: true }, isBoolean), true);
 });
 Deno.test("isObject<T> returns false on non T object", () => {
   assertEquals(isObject({ a: 0 }, isString), false);
   assertEquals(isObject({ a: "a" }, isNumber), false);
+  assertEquals(isObject({ a: true }, isString), false);
 });
 
 Deno.test("isFunction returns true on function", () => {
@@ -91,6 +118,8 @@ Deno.test("isFunction returns true on function", () => {
 Deno.test("isFunction returns false on non function", () => {
   assertEquals(isFunction(""), false);
   assertEquals(isFunction(0), false);
+  assertEquals(isFunction(true), false);
+  assertEquals(isFunction(false), false);
   assertEquals(isFunction([]), false);
   assertEquals(isFunction({}), false);
   assertEquals(isFunction(null), false);
@@ -103,6 +132,8 @@ Deno.test("isNull returns true on null", () => {
 Deno.test("isNull returns false on non null", () => {
   assertEquals(isNull(""), false);
   assertEquals(isNull(0), false);
+  assertEquals(isNull(true), false);
+  assertEquals(isNull(false), false);
   assertEquals(isNull([]), false);
   assertEquals(isNull({}), false);
   assertEquals(isNull(function () {}), false);
@@ -115,6 +146,8 @@ Deno.test("isUndefined returns true on null", () => {
 Deno.test("isUndefined returns false on non null", () => {
   assertEquals(isUndefined(""), false);
   assertEquals(isUndefined(0), false);
+  assertEquals(isUndefined(true), false);
+  assertEquals(isUndefined(false), false);
   assertEquals(isUndefined([]), false);
   assertEquals(isUndefined({}), false);
   assertEquals(isUndefined(function () {}), false);
@@ -128,6 +161,8 @@ Deno.test("isNone returns true on null/undefined", () => {
 Deno.test("isNone returns false on non null/undefined", () => {
   assertEquals(isNone(""), false);
   assertEquals(isNone(0), false);
+  assertEquals(isNone(true), false);
+  assertEquals(isNone(false), false);
   assertEquals(isNone([]), false);
   assertEquals(isNone({}), false);
   assertEquals(isNone(function () {}), false);
@@ -139,6 +174,8 @@ Deno.test("isLike returns true/false on string", () => {
   assertEquals(isLike(ref, "Hello World"), true);
 
   assertEquals(isLike(ref, 0), false);
+  assertEquals(isLike(ref, true), false);
+  assertEquals(isLike(ref, false), false);
   assertEquals(isLike(ref, []), false);
   assertEquals(isLike(ref, {}), false);
   assertEquals(isLike(ref, function () {}), false);
@@ -150,6 +187,21 @@ Deno.test("isLike returns true/false on number", () => {
   assertEquals(isLike(ref, 0), true);
   assertEquals(isLike(ref, 1234567890), true);
 
+  assertEquals(isLike(ref, ""), false);
+  assertEquals(isLike(ref, true), false);
+  assertEquals(isLike(ref, false), false);
+  assertEquals(isLike(ref, []), false);
+  assertEquals(isLike(ref, {}), false);
+  assertEquals(isLike(ref, function () {}), false);
+  assertEquals(isLike(ref, null), false);
+  assertEquals(isLike(ref, undefined), false);
+});
+Deno.test("isLike returns true/false on boolean", () => {
+  const ref = true;
+  assertEquals(isLike(ref, true), true);
+  assertEquals(isLike(ref, false), true);
+
+  assertEquals(isLike(ref, 0), false);
   assertEquals(isLike(ref, ""), false);
   assertEquals(isLike(ref, []), false);
   assertEquals(isLike(ref, {}), false);
@@ -166,6 +218,8 @@ Deno.test("isLike returns true/false on array", () => {
 
   assertEquals(isLike(ref, ""), false);
   assertEquals(isLike(ref, 0), false);
+  assertEquals(isLike(ref, true), false);
+  assertEquals(isLike(ref, false), false);
   assertEquals(isLike(ref, {}), false);
   assertEquals(isLike(ref, function () {}), false);
   assertEquals(isLike(ref, null), false);
@@ -175,9 +229,11 @@ Deno.test("isLike returns true/false on T array", () => {
   const ref: unknown[] = [];
   assertEquals(isLike(ref, [0, 1, 2], isNumber), true);
   assertEquals(isLike(ref, ["a", "b", "c"], isString), true);
+  assertEquals(isLike(ref, [true, false, true], isBoolean), true);
 
   assertEquals(isLike(ref, [0, 1, 2], isString), false);
   assertEquals(isLike(ref, ["a", "b", "c"], isNumber), false);
+  assertEquals(isLike(ref, [true, false, true], isString), false);
 });
 Deno.test("isLike returns true/false on tuple", () => {
   const ref = ["", 0, ""];
@@ -194,9 +250,12 @@ Deno.test("isLike returns true/false on object", () => {
   assertEquals(isLike(ref, {}), true);
   assertEquals(isLike(ref, { a: 0 }), true);
   assertEquals(isLike(ref, { a: "a" }), true);
+  assertEquals(isLike(ref, { a: true }), true);
 
   assertEquals(isLike(ref, ""), false);
   assertEquals(isLike(ref, 0), false);
+  assertEquals(isLike(ref, true), false);
+  assertEquals(isLike(ref, false), false);
   assertEquals(isLike(ref, []), false);
   assertEquals(isLike(ref, function () {}), false);
   assertEquals(isLike(ref, null), false);
@@ -206,9 +265,11 @@ Deno.test("isLike returns true/false on T object", () => {
   const ref = {};
   assertEquals(isLike(ref, { a: 0 }, isNumber), true);
   assertEquals(isLike(ref, { a: "a" }, isString), true);
+  assertEquals(isLike(ref, { a: true }, isBoolean), true);
 
   assertEquals(isLike(ref, { a: 0 }, isString), false);
   assertEquals(isLike(ref, { a: "a" }, isNumber), false);
+  assertEquals(isLike(ref, { a: true }, isString), false);
 });
 Deno.test("isLike returns true/false on struct", () => {
   const ref = { foo: "", bar: 0 };
@@ -232,6 +293,8 @@ Deno.test("isLike returns true/false on function", () => {
 
   assertEquals(isLike(ref, ""), false);
   assertEquals(isLike(ref, 0), false);
+  assertEquals(isLike(ref, true), false);
+  assertEquals(isLike(ref, false), false);
   assertEquals(isLike(ref, []), false);
   assertEquals(isLike(ref, {}), false);
   assertEquals(isLike(ref, null), false);
@@ -243,6 +306,8 @@ Deno.test("isLike returns true/false on null", () => {
 
   assertEquals(isLike(ref, ""), false);
   assertEquals(isLike(ref, 0), false);
+  assertEquals(isLike(ref, true), false);
+  assertEquals(isLike(ref, false), false);
   assertEquals(isLike(ref, []), false);
   assertEquals(isLike(ref, {}), false);
   assertEquals(isLike(ref, function () {}), false);
@@ -254,6 +319,8 @@ Deno.test("isLike returns true/false on undefined", () => {
 
   assertEquals(isLike(ref, ""), false);
   assertEquals(isLike(ref, 0), false);
+  assertEquals(isLike(ref, true), false);
+  assertEquals(isLike(ref, false), false);
   assertEquals(isLike(ref, []), false);
   assertEquals(isLike(ref, {}), false);
   assertEquals(isLike(ref, function () {}), false);


### PR DESCRIPTION
Added the ability to compare objects/arrays containing bool types with isLike.

To achieve this, I have added two functions and their corresponding tests.

- `isBoolean(x: unknown): x is boolean` : returns true if and only if `x` is boolean
- `ensureBoolean(x: unknown): asserts x is boolean` : ensures `x` is boolean