### PR TITLE
:+1: Add `isUniformTupleOf`

### DIFF
--- a/is.ts
+++ b/is.ts
@@ -82,6 +82,39 @@ export function isTupleOf<T extends readonly Predicate<unknown>[]>(
   };
 }
 
+// https://stackoverflow.com/a/71700658/1273406
+export type UniformTupleOf<
+  T,
+  N extends number,
+  R extends readonly T[] = [],
+> = R["length"] extends N ? R : UniformTupleOf<T, N, readonly [T, ...R]>;
+
+/**
+ * Return a type predicate function that returns `true` if the type of `x` is `UniformTupleOf<T>`.
+ *
+ * ```ts
+ * import is from "./is.ts";
+ *
+ * const a: unknown = [0, 1, 2, 3, 4];
+ * if (is.UniformTupleOf(5)(a)) {
+ *  // a is narrowed to [unknown, unknown, unknown, unknown, unknown]
+ *  const _: readonly [unknown, unknown, unknown, unknown, unknown] = a;
+ * }
+ *
+ * if (is.UniformTupleOf(5, is.Number)(a)) {
+ *  // a is narrowed to [number, number, number, number, number]
+ *  const _: readonly [number, number, number, number, number] = a;
+ * }
+ * ```
+ */
+export function isUniformTupleOf<T, N extends number>(
+  n: N,
+  pred: Predicate<T> = (_x: unknown): _x is T => true,
+): Predicate<UniformTupleOf<T, N>> {
+  const predTup = Array(n).fill(pred);
+  return isTupleOf(predTup) as Predicate<UniformTupleOf<T, N>>;
+}
+
 /**
  * Synonym of `Record<string | number | symbol, T>`
  */
@@ -248,6 +281,7 @@ export default {
   Array: isArray,
   ArrayOf: isArrayOf,
   TupleOf: isTupleOf,
+  UniformTupleOf: isUniformTupleOf,
   Record: isRecord,
   RecordOf: isRecordOf,
   ObjectOf: isObjectOf,

--- a/is_test.ts
+++ b/is_test.ts
@@ -20,6 +20,7 @@ import is, {
   isSymbol,
   isTupleOf,
   isUndefined,
+  isUniformTupleOf,
   Predicate,
 } from "./is.ts";
 
@@ -116,6 +117,28 @@ Deno.test("isTupleOf<T>", async (t) => {
     assertEquals(isTupleOf(predTup)([0, 1, 2]), false);
     assertEquals(isTupleOf(predTup)([0, "a"]), false);
     assertEquals(isTupleOf(predTup)([0, "a", true, 0]), false);
+  });
+});
+
+Deno.test("isUniformTupleOf<T>", async (t) => {
+  await t.step("returns proper type predicate", () => {
+    const a: unknown = [0, 1, 2, 3, 4];
+    if (isUniformTupleOf(5)(a)) {
+      const _: readonly [unknown, unknown, unknown, unknown, unknown] = a;
+    }
+
+    if (isUniformTupleOf(5, isNumber)(a)) {
+      const _: readonly [number, number, number, number, number] = a;
+    }
+  });
+  await t.step("returns true on mono-typed T tuple", () => {
+    assertEquals(isUniformTupleOf(3)([0, 1, 2]), true);
+    assertEquals(isUniformTupleOf(3, is.Number)([0, 1, 2]), true);
+  });
+  await t.step("returns false on non mono-typed T tuple", () => {
+    assertEquals(isUniformTupleOf(4)([0, 1, 2]), false);
+    assertEquals(isUniformTupleOf(4)([0, 1, 2, 3, 4]), false);
+    assertEquals(isUniformTupleOf(3, is.Number)(["a", "b", "c"]), false);
   });
 });
 


### PR DESCRIPTION
```ts
import is from "./is.ts";

const a: unknown = [0, 1, 2, 3, 4];
if (is.UniformTupleOf(5)(a)) {
 // a is narrowed to [unknown, unknown, unknown, unknown, unknown]
 const _: readonly [unknown, unknown, unknown, unknown, unknown] = a;
}

if (is.UniformTupleOf(5, is.Number)(a)) {
 // a is narrowed to [number, number, number, number, number]
 const _: readonly [number, number, number, number, number] = a;
}
```
