### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/is_test.ts
+++ b/is_test.ts
@@ -1,11 +1,11 @@
 import {
   assertEquals,
   assertStrictEquals,
-} from "https://deno.land/std@0.192.0/testing/asserts.ts";
+} from "https://deno.land/std@0.200.0/testing/asserts.ts";
 import type {
   AssertTrue,
   IsExact,
-} from "https://deno.land/std@0.192.0/testing/types.ts";
+} from "https://deno.land/std@0.200.0/testing/types.ts";
 import is, {
   isAllOf,
   isArray,

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -1,4 +1,4 @@
-import { build, emptyDir } from "https://deno.land/x/dnt@0.37.0/mod.ts";
+import { build, emptyDir } from "https://deno.land/x/dnt@0.38.1/mod.ts";
 
 const name = "unknownutil";
 const version = Deno.args[0];

--- a/util_test.ts
+++ b/util_test.ts
@@ -1,7 +1,7 @@
 import {
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@0.192.0/testing/asserts.ts";
+} from "https://deno.land/std@0.200.0/testing/asserts.ts";
 import { assert, AssertError, ensure, maybe } from "./util.ts";
 
 const x: unknown = Symbol("x");


### PR DESCRIPTION
The output of `make update` is

```
/home/runner/work/deno-unknownutil/deno-unknownutil/scripts/build_npm.ts
[1/1] Looking for releases: https://deno.land/x/dnt@0.37.0/mod.ts
[1/1] Attempting update: https://deno.land/x/dnt@0.37.0/mod.ts -> 0.38.1
[1/1] Update successful: https://deno.land/x/dnt@0.37.0/mod.ts -> 0.38.1

/home/runner/work/deno-unknownutil/deno-unknownutil/is_bench.ts

/home/runner/work/deno-unknownutil/deno-unknownutil/is.ts

/home/runner/work/deno-unknownutil/deno-unknownutil/mod.ts

/home/runner/work/deno-unknownutil/deno-unknownutil/is_test.ts
[1/2] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.200.0
[1/2] Update successful: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.200.0
[2/2] Looking for releases: https://deno.land/std@0.192.0/testing/types.ts
[2/2] Attempting update: https://deno.land/std@0.192.0/testing/types.ts -> 0.200.0
[2/2] Update successful: https://deno.land/std@0.192.0/testing/types.ts -> 0.200.0

/home/runner/work/deno-unknownutil/deno-unknownutil/util.ts

/home/runner/work/deno-unknownutil/deno-unknownutil/util_test.ts
[1/1] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.200.0
[1/1] Update successful: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.200.0

Successfully updated:
https://deno.land/x/dnt@0.37.0/mod.ts 0.37.0 -> 0.38.1
https://deno.land/std@0.192.0/testing/asserts.ts 0.192.0 -> 0.200.0
https://deno.land/std@0.192.0/testing/types.ts 0.192.0 -> 0.200.0
https://deno.land/std@0.192.0/testing/asserts.ts 0.192.0 -> 0.200.0

```