### PR TITLE
Allow `isObjectOf` to specify an optional property

### DIFF
--- a/is.ts
+++ b/is.ts
@@ -273,6 +273,27 @@ export function isOneOf<T extends readonly Predicate<unknown>[]>(
   return (x: unknown): x is OneOf<T> => preds.some((pred) => pred(x));
 }
 
+export type OptionalPredicate<T> = Predicate<T | undefined>;
+
+/**
+ * Return a type predicate function that returns `true` if the type of `x` is `T` or `undefined`.
+ *
+ * ```ts
+ * import is from "./is.ts";
+ *
+ * const a: unknown = "a";
+ * if (is.OptionalOf(is.String)(a)) {
+ *  // a is narrowed to string | undefined;
+ *  const _: string | undefined = a;
+ * }
+ * ```
+ */
+export function isOptionalOf<T>(
+  pred: Predicate<T>,
+): OptionalPredicate<T> {
+  return isOneOf([isUndefined, pred]);
+}
+
 export default {
   String: isString,
   Number: isNumber,
@@ -292,4 +313,5 @@ export default {
   Nullish: isNullish,
   Symbol: isSymbol,
   OneOf: isOneOf,
+  OptionalOf: isOptionalOf,
 };

--- a/is.ts
+++ b/is.ts
@@ -146,12 +146,24 @@ type FlatType<T> = T extends RecordOf<unknown>
   ? { [K in keyof T]: FlatType<T[K]> }
   : T;
 
-export type ObjectOf<
-  T extends RecordOf<Predicate<unknown>>,
-> = FlatType<{ [K in keyof T]: T[K] extends Predicate<infer U> ? U : never }>;
+type OptionalPredicateKeys<T extends RecordOf<unknown>> = {
+  [K in keyof T]: T[K] extends OptionalPredicate<unknown> ? K : never;
+}[keyof T];
+
+export type ObjectOf<T extends RecordOf<Predicate<unknown>>> = FlatType<
+  & {
+    [K in Exclude<keyof T, OptionalPredicateKeys<T>>]: T[K] extends
+      Predicate<infer U> ? U : never;
+  }
+  & {
+    [K in OptionalPredicateKeys<T>]?: T[K] extends Predicate<infer U> ? U
+      : never;
+  }
+>;
 
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `ObjectOf<T>`.
+ * If `is.OptionalOf()` is specified in the predicate function, the property becomes optional.
  * When `options.strict` is `true`, the number of keys of `x` must be equal to the number of keys of `predObj`.
  * Otherwise, the number of keys of `x` must be greater than or equal to the number of keys of `predObj`.
  *
@@ -161,12 +173,12 @@ export type ObjectOf<
  * const predObj = {
  *  a: is.Number,
  *  b: is.String,
- *  c: is.Boolean,
+ *  c: is.OptionalOf(is.Boolean),
  * };
- * const a: unknown = { a: 0, b: "a", c: true };
+ * const a: unknown = { a: 0, b: "a" };
  * if (is.ObjectOf(predObj)(a)) {
- *  // a is narrowed to { a: number, b: string, c: boolean }
- *  const _: { a: number, b: string, c: boolean } = a;
+ *  // a is narrowed to { a: number, b: string, c?: boolean }
+ *  const _: { a: number, b: string, c?: boolean } = a;
  * }
  * ```
  */
@@ -176,22 +188,16 @@ export function isObjectOf<
   predObj: T,
   options: { strict?: boolean } = {},
 ): Predicate<ObjectOf<T>> {
-  return (x: unknown): x is ObjectOf<T> => {
-    if (!isRecord(x)) {
-      return false;
-    }
-    const preds = Object.entries<Predicate<unknown>>(predObj);
-    if (options.strict) {
-      if (Object.keys(x).length !== preds.length) {
-        return false;
-      }
-    } else {
-      if (Object.keys(x).length < preds.length) {
-        return false;
-      }
-    }
-    return preds.every(([k, p]) => p(x[k]));
-  };
+  const preds = Object.entries(predObj);
+  const allKeys = new Set(preds.map(([key]) => key));
+  const requiredKeys = preds
+    .filter(([_, pred]) => !(pred as OptionalPredicate<unknown>).optional)
+    .map(([key]) => key);
+  const hasKeys = options.strict
+    ? (props: string[]) => props.every((p) => allKeys.has(p))
+    : (props: string[]) => requiredKeys.every((k) => props.includes(k));
+  return (x: unknown): x is ObjectOf<T> =>
+    isRecord(x) && hasKeys(Object.keys(x)) && preds.every(([k, p]) => p(x[k]));
 }
 
 /**
@@ -273,7 +279,9 @@ export function isOneOf<T extends readonly Predicate<unknown>[]>(
   return (x: unknown): x is OneOf<T> => preds.some((pred) => pred(x));
 }
 
-export type OptionalPredicate<T> = Predicate<T | undefined>;
+export type OptionalPredicate<T> = Predicate<T | undefined> & {
+  optional: true;
+};
 
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `T` or `undefined`.
@@ -291,7 +299,9 @@ export type OptionalPredicate<T> = Predicate<T | undefined>;
 export function isOptionalOf<T>(
   pred: Predicate<T>,
 ): OptionalPredicate<T> {
-  return isOneOf([isUndefined, pred]);
+  return Object.assign(isOneOf([isUndefined, pred]), {
+    optional: true as const,
+  });
 }
 
 export default {

--- a/is_bench.ts
+++ b/is_bench.ts
@@ -196,3 +196,13 @@ Deno.bench({
     }
   },
 });
+
+Deno.bench({
+  name: "is.OptionalOf",
+  fn: () => {
+    const pred = is.OptionalOf(is.String);
+    for (const c of cs) {
+      pred(c);
+    }
+  },
+});

--- a/is_test.ts
+++ b/is_test.ts
@@ -18,6 +18,7 @@ import is, {
   isNumber,
   isObjectOf,
   isOneOf,
+  isOptionalOf,
   isRecord,
   isRecordOf,
   isString,
@@ -342,6 +343,65 @@ Deno.test("isOneOf<T>", async (t) => {
     const preds = [isNumber, isString, isBoolean];
     await testWithExamples(t, isOneOf(preds), {
       excludeExamples: ["number", "string", "boolean"],
+    });
+  });
+});
+
+Deno.test("isOptionalOf<T>", async (t) => {
+  await t.step("returns proper type predicate", () => {
+    const a: unknown = undefined;
+    if (isOptionalOf(isNumber)(a)) {
+      type _ = AssertTrue<IsExact<typeof a, number | undefined>>;
+    }
+  });
+  await t.step("with isString", async (t) => {
+    await testWithExamples(t, isOptionalOf(isString), {
+      validExamples: ["string", "undefined"],
+    });
+  });
+  await t.step("with isNumber", async (t) => {
+    await testWithExamples(t, isOptionalOf(isNumber), {
+      validExamples: ["number", "undefined"],
+    });
+  });
+  await t.step("with isBigInt", async (t) => {
+    await testWithExamples(t, isOptionalOf(isBigInt), {
+      validExamples: ["bigint", "undefined"],
+    });
+  });
+  await t.step("with isBoolean", async (t) => {
+    await testWithExamples(t, isOptionalOf(isBoolean), {
+      validExamples: ["boolean", "undefined"],
+    });
+  });
+  await t.step("with isArray", async (t) => {
+    await testWithExamples(t, isOptionalOf(isArray), {
+      validExamples: ["array", "undefined"],
+    });
+  });
+  await t.step("with isRecord", async (t) => {
+    await testWithExamples(t, isOptionalOf(isRecord), {
+      validExamples: ["record", "date", "promise", "undefined"],
+    });
+  });
+  await t.step("with isFunction", async (t) => {
+    await testWithExamples(t, isOptionalOf(isFunction), {
+      validExamples: ["function", "undefined"],
+    });
+  });
+  await t.step("with isNull", async (t) => {
+    await testWithExamples(t, isOptionalOf(isNull), {
+      validExamples: ["null", "undefined"],
+    });
+  });
+  await t.step("with isUndefined", async (t) => {
+    await testWithExamples(t, isOptionalOf(isUndefined), {
+      validExamples: ["undefined"],
+    });
+  });
+  await t.step("with isSymbol", async (t) => {
+    await testWithExamples(t, isOptionalOf(isSymbol), {
+      validExamples: ["symbol", "undefined"],
     });
   });
 });

--- a/is_test.ts
+++ b/is_test.ts
@@ -2,6 +2,10 @@ import {
   assertEquals,
   assertStrictEquals,
 } from "https://deno.land/std@0.192.0/testing/asserts.ts";
+import type {
+  AssertTrue,
+  IsExact,
+} from "https://deno.land/std@0.192.0/testing/types.ts";
 import is, {
   isArray,
   isArrayOf,
@@ -86,7 +90,7 @@ Deno.test("isArrayOf<T>", async (t) => {
   await t.step("returns proper type predicate", () => {
     const a: unknown = [0, 1, 2];
     if (isArrayOf(isNumber)(a)) {
-      const _: number[] = a;
+      type _ = AssertTrue<IsExact<typeof a, number[]>>;
     }
   });
   await t.step("returns true on T array", () => {
@@ -106,7 +110,9 @@ Deno.test("isTupleOf<T>", async (t) => {
     const predTup = [isNumber, isString, isBoolean] as const;
     const a: unknown = [0, "a", true];
     if (isTupleOf(predTup)(a)) {
-      const _: readonly [number, string, boolean] = a;
+      type _ = AssertTrue<
+        IsExact<typeof a, readonly [number, string, boolean]>
+      >;
     }
   });
   await t.step("returns true on T tuple", () => {
@@ -125,11 +131,18 @@ Deno.test("isUniformTupleOf<T>", async (t) => {
   await t.step("returns proper type predicate", () => {
     const a: unknown = [0, 1, 2, 3, 4];
     if (isUniformTupleOf(5)(a)) {
-      const _: readonly [unknown, unknown, unknown, unknown, unknown] = a;
+      type _ = AssertTrue<
+        IsExact<
+          typeof a,
+          readonly [unknown, unknown, unknown, unknown, unknown]
+        >
+      >;
     }
 
     if (isUniformTupleOf(5, isNumber)(a)) {
-      const _: readonly [number, number, number, number, number] = a;
+      type _ = AssertTrue<
+        IsExact<typeof a, readonly [number, number, number, number, number]>
+      >;
     }
   });
   await t.step("returns true on mono-typed T tuple", () => {
@@ -151,7 +164,9 @@ Deno.test("isRecordOf<T>", async (t) => {
   await t.step("returns proper type predicate", () => {
     const a: unknown = { a: 0 };
     if (isRecordOf(isNumber)(a)) {
-      const _: Record<string | number | symbol, number> = a;
+      type _ = AssertTrue<
+        IsExact<typeof a, Record<string | number | symbol, number>>
+      >;
     }
   });
   await t.step("returns true on T record", () => {
@@ -175,7 +190,9 @@ Deno.test("isObjectOf<T>", async (t) => {
     };
     const a: unknown = { a: 0, b: "a", c: true };
     if (isObjectOf(predObj)(a)) {
-      const _: { a: number; b: string; c: boolean } = a;
+      type _ = AssertTrue<
+        IsExact<typeof a, { a: number; b: string; c: boolean }>
+      >;
     }
   });
   await t.step("returns true on T object", () => {
@@ -239,17 +256,17 @@ Deno.test("isInstanceOf<T>", async (t) => {
     class Cls {}
     const a: unknown = new Cls();
     if (isInstanceOf(Cls)(a)) {
-      const _: Cls = a;
+      type _ = AssertTrue<IsExact<typeof a, Cls>>;
     }
 
     const b: unknown = new Date();
     if (isInstanceOf(Date)(b)) {
-      const _: Date = b;
+      type _ = AssertTrue<IsExact<typeof b, Date>>;
     }
 
     const c: unknown = new Promise(() => {});
     if (isInstanceOf(Promise)(c)) {
-      const _: Promise<unknown> = c;
+      type _ = AssertTrue<IsExact<typeof c, Promise<unknown>>>;
     }
   });
 });
@@ -275,7 +292,7 @@ Deno.test("isOneOf<T>", async (t) => {
     const preds = [isNumber, isString, isBoolean];
     const a: unknown = [0, "a", true];
     if (isOneOf(preds)(a)) {
-      const _: number | string | boolean = a;
+      type _ = AssertTrue<IsExact<typeof a, number | string | boolean>>;
     }
   });
   await t.step("returns true on one of T", () => {

--- a/is_test.ts
+++ b/is_test.ts
@@ -294,17 +294,21 @@ Deno.test("isOneOf<T>", async (t) => {
   });
 });
 
-Deno.test("is defines aliases of functions", async () => {
+Deno.test("is", async (t) => {
   const mod = await import("./is.ts");
-  const cases = Object.entries(mod)
+  const casesOfAliasAndIsFunction = Object.entries(mod)
     .filter(([k, _]) => k.startsWith("is"))
     .map(([k, v]) => [k.slice(2), v] as const);
-  for (const [alias, fn] of cases) {
-    assertStrictEquals(is[alias as keyof typeof is], fn);
+  for (const [alias, fn] of casesOfAliasAndIsFunction) {
+    await t.step(`defines \`${alias}\` function`, () => {
+      assertStrictEquals(is[alias as keyof typeof is], fn);
+    });
   }
-  assertEquals(
-    Object.keys(is).length,
-    cases.length,
-    "The number of entries in `is` is not equal to `is*` functions",
+  await t.step(
+    "only has entries that are the same as the `is*` function aliases",
+    () => {
+      const aliases = casesOfAliasAndIsFunction.map(([a]) => a).toSorted();
+      assertEquals(Object.keys(is).toSorted(), aliases);
+    },
   );
 });

--- a/is_test.ts
+++ b/is_test.ts
@@ -40,6 +40,7 @@ const examples = {
 function stringify(x: unknown): string {
   if (typeof x === "function") return x.toString();
   if (typeof x === "bigint") return `${x}n`;
+  if (typeof x === "symbol") return x.toString();
   return JSON.stringify(x);
 }
 


### PR DESCRIPTION
Example

```ts
import is from "./is.ts";
                                                           
const predObj = {
 a: is.Number,
 b: is.String,
 c: is.OptionalOf(is.Boolean),
};
const a: unknown = { a: 0, b: "a" };
if (is.ObjectOf(predObj)(a)) {
 // a is narrowed to { a: number, b: string, c?: boolean }
 const _: { a: number, b: string, c?: boolean } = a;
}
```