### PR TITLE
:+1: Add `PredicateType<P>` to infer `T` of `Predicate<T>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Additionally, `is*Of` (or `is.*Of`) functions return type predicate functions to
 predicate types of `x` more precisely like:
 
 ```typescript
-import { is } from "./mod.ts";
+import { is, PredicateType } from "./mod.ts";
 
 const isArticle = is.ObjectOf({
   title: is.String,
@@ -47,6 +47,8 @@ const isArticle = is.ObjectOf({
     }),
   ])),
 });
+
+type Article = PredicateType<typeof isArticle>;
 
 const a: unknown = {
   title: "Awesome article",

--- a/is.ts
+++ b/is.ts
@@ -4,6 +4,11 @@
 export type Predicate<T> = (x: unknown) => x is T;
 
 /**
+ * A type predicated by Predicate<T>
+ */
+export type PredicateType<P> = P extends Predicate<infer T> ? T : never;
+
+/**
  * Return `true` if the type of `x` is `string`.
  */
 export function isString(x: unknown): x is string {

--- a/is_test.ts
+++ b/is_test.ts
@@ -1,11 +1,11 @@
 import {
   assertEquals,
   assertStrictEquals,
-} from "https://deno.land/std@0.200.0/testing/asserts.ts";
+} from "https://deno.land/std@0.202.0/assert/mod.ts";
 import type {
   AssertTrue,
   IsExact,
-} from "https://deno.land/std@0.200.0/testing/types.ts";
+} from "https://deno.land/std@0.202.0/testing/types.ts";
 import is, {
   isAllOf,
   isArray,

--- a/is_test.ts
+++ b/is_test.ts
@@ -31,6 +31,7 @@ import is, {
   isUndefined,
   isUniformTupleOf,
   Predicate,
+  PredicateType,
 } from "./is.ts";
 
 const examples = {
@@ -82,6 +83,30 @@ async function testWithExamples<T>(
     }
   }
 }
+
+Deno.test("PredicateType", () => {
+  const isArticle = is.ObjectOf({
+    title: is.String,
+    body: is.String,
+    refs: is.ArrayOf(is.OneOf([
+      is.String,
+      is.ObjectOf({
+        name: is.String,
+        url: is.String,
+      }),
+    ])),
+  });
+  type _ = AssertTrue<
+    IsExact<
+      PredicateType<typeof isArticle>,
+      {
+        title: string;
+        body: string;
+        refs: (string | { name: string; url: string })[];
+      }
+    >
+  >;
+});
 
 Deno.test("isString", async (t) => {
   await testWithExamples(t, isString, { validExamples: ["string"] });

--- a/util_test.ts
+++ b/util_test.ts
@@ -1,7 +1,7 @@
 import {
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@0.200.0/testing/asserts.ts";
+} from "https://deno.land/std@0.202.0/assert/mod.ts";
 import {
   assert,
   AssertError,


### PR DESCRIPTION
Now users can infer `T` from `Predicate<T>` so that they don't need to define type definition twice

### Before

```ts
const isArticle = is.ObjectOf({
  title: is.String,
  body: is.String,
  refs: is.ArrayOf(is.OneOf([
    is.String,
    is.ObjectOf({
      name: is.String,
      url: is.String,
    }),
  ])),
});

type Article = {
  title: string;
  body: string;
  refs: (string | {
    name: string;
    url: string;
  })[];
};
```

### After

```ts
const isArticle = is.ObjectOf({
  title: is.String,
  body: is.String,
  refs: is.ArrayOf(is.OneOf([
    is.String,
    is.ObjectOf({
      name: is.String,
      url: is.String,
    }),
  ])),
});

type Article = PredicateType<typeof isArticle>;
```