### PR TITLE
:+1: Add name property to type predicate functions

### DIFF
--- a/__snapshots__/inspect_test.ts.snap
+++ b/__snapshots__/inspect_test.ts.snap
@@ -1,0 +1,45 @@
+export const snapshot = {};
+
+snapshot[`inspect > string 1`] = `'"hello world"'`;
+
+snapshot[`inspect > number 1`] = `"100"`;
+
+snapshot[`inspect > bigint 1`] = `"100n"`;
+
+snapshot[`inspect > boolean 1`] = `"true"`;
+
+snapshot[`inspect > array 1`] = `"[]"`;
+
+snapshot[`inspect > array 2`] = `"[0, 1, 2]"`;
+
+snapshot[`inspect > array 3`] = `'[0, "a", true]'`;
+
+snapshot[`inspect > array 4`] = `"[0, [1, [2]]]"`;
+
+snapshot[`inspect > record 1`] = `"{}"`;
+
+snapshot[`inspect > record 2`] = `"{a: 0, b: 1, c: 2}"`;
+
+snapshot[`inspect > record 3`] = `
+'{
+  a: "a",
+  b: 1,
+  c: true
+}'
+`;
+
+snapshot[`inspect > record 4`] = `"{a: {b: {c: 0}}}"`;
+
+snapshot[`inspect > function 1`] = `"inspect"`;
+
+snapshot[`inspect > function 2`] = `"(anonymous)"`;
+
+snapshot[`inspect > null 1`] = `"null"`;
+
+snapshot[`inspect > undefined 1`] = `"undefined"`;
+
+snapshot[`inspect > symbol 1`] = `"Symbol(a)"`;
+
+snapshot[`inspect > date 1`] = `"Date"`;
+
+snapshot[`inspect > promise 1`] = `"Promise"`;

--- a/__snapshots__/is_test.ts.snap
+++ b/__snapshots__/is_test.ts.snap
@@ -1,0 +1,92 @@
+export const snapshot = {};
+
+snapshot[`isArrayOf<T> > returns properly named function 1`] = `"isArrayOf(isNumber)"`;
+
+snapshot[`isArrayOf<T> > returns properly named function 2`] = `"isArrayOf((anonymous))"`;
+
+snapshot[`isTupleOf<T> > returns properly named function 1`] = `
+"isTupleOf([
+  isNumber,
+  isString,
+  isBoolean
+])"
+`;
+
+snapshot[`isTupleOf<T> > returns properly named function 2`] = `"isTupleOf([(anonymous)])"`;
+
+snapshot[`isTupleOf<T> > returns properly named function 3`] = `
+"isTupleOf([
+  isTupleOf([
+    isTupleOf([
+      isNumber,
+      isString,
+      isBoolean
+    ])
+  ])
+])"
+`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 1`] = `"isUniformTupleOf(3, isAny)"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 2`] = `"isUniformTupleOf(3, isNumber)"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 3`] = `"isUniformTupleOf(3, (anonymous))"`;
+
+snapshot[`isRecordOf<T> > returns properly named function 1`] = `"isRecordOf(isNumber)"`;
+
+snapshot[`isRecordOf<T> > returns properly named function 2`] = `"isRecordOf((anonymous))"`;
+
+snapshot[`isObjectOf<T> > returns properly named function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  b: isString,
+  c: isBoolean
+})"
+`;
+
+snapshot[`isObjectOf<T> > returns properly named function 2`] = `"isObjectOf({a: a})"`;
+
+snapshot[`isObjectOf<T> > returns properly named function 3`] = `
+"isObjectOf({
+  a: isObjectOf({
+    b: isObjectOf({c: isBoolean})
+  })
+})"
+`;
+
+snapshot[`isInstanceOf<T> > returns properly named function 1`] = `"isInstanceOf(Date)"`;
+
+snapshot[`isInstanceOf<T> > returns properly named function 2`] = `"isInstanceOf((anonymous))"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 1`] = `'isLiteralOf("hello")'`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 2`] = `"isLiteralOf(100)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 3`] = `"isLiteralOf(100n)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 4`] = `"isLiteralOf(true)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 5`] = `"isLiteralOf(null)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 6`] = `"isLiteralOf(undefined)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 7`] = `"isLiteralOf(Symbol(asdf))"`;
+
+snapshot[`isLiteralOneOf<T> > returns properly named function 1`] = `'isLiteralOneOf(["hello", "world"])'`;
+
+snapshot[`isOneOf<T> > returns properly named function 1`] = `
+"isOneOf([
+  isNumber,
+  isString,
+  isBoolean
+])"
+`;
+
+snapshot[`isAllOf<T> > returns properly named function 1`] = `
+"isAllOf([
+  isObjectOf({a: isNumber}),
+  isObjectOf({b: isString})
+])"
+`;
+
+snapshot[`isOptionalOf<T> > returns properly named function 1`] = `"isOptionalOf(isNumber)"`;

--- a/inspect.ts
+++ b/inspect.ts
@@ -1,0 +1,59 @@
+const defaultThreshold = 20;
+
+export type InspectOptions = {
+  // The maximum number of characters of a single attribute
+  threshold?: number;
+};
+
+/**
+ * Inspect a value
+ */
+export function inspect(value: unknown, options: InspectOptions = {}): string {
+  if (value === null) {
+    return "null";
+  } else if (Array.isArray(value)) {
+    return inspectArray(value, options);
+  }
+  switch (typeof value) {
+    case "string":
+      return JSON.stringify(value);
+    case "bigint":
+      return `${value}n`;
+    case "object":
+      if (value.constructor?.name !== "Object") {
+        return value.constructor?.name;
+      }
+      return inspectRecord(value as Record<PropertyKey, unknown>, options);
+    case "function":
+      return value.name || "(anonymous)";
+  }
+  return value?.toString() ?? "undefined";
+}
+
+function inspectArray(value: unknown[], options: InspectOptions): string {
+  const { threshold = defaultThreshold } = options;
+  const vs = value.map((v) => inspect(v, options));
+  const s = vs.join(", ");
+  if (s.length <= threshold) return `[${s}]`;
+  const m = vs.join(",\n");
+  return `[\n${indent(2, m)}\n]`;
+}
+
+function inspectRecord(
+  value: Record<PropertyKey, unknown>,
+  options: InspectOptions,
+): string {
+  const { threshold = defaultThreshold } = options;
+  const vs = Object.entries(value).map(([k, v]) =>
+    `${k}: ${inspect(v, options)}`
+  );
+  const s = vs.join(", ");
+  if (s.length <= threshold) return `{${s}}`;
+  const m = vs.join(",\n");
+  return `{\n${indent(2, m)}\n}`;
+}
+
+function indent(level: number, text: string): string {
+  const prefix = "  ".repeat(level);
+  return text.split("\n").map((line) => `${prefix}${line}`).join("\n");
+}

--- a/inspect.ts
+++ b/inspect.ts
@@ -54,6 +54,6 @@ function inspectRecord(
 }
 
 function indent(level: number, text: string): string {
-  const prefix = "  ".repeat(level);
+  const prefix = " ".repeat(level);
   return text.split("\n").map((line) => `${prefix}${line}`).join("\n");
 }

--- a/inspect_test.ts
+++ b/inspect_test.ts
@@ -1,0 +1,50 @@
+import {
+  assertSnapshot,
+} from "https://deno.land/std@0.202.0/testing/snapshot.ts";
+import { inspect } from "./inspect.ts";
+
+Deno.test("inspect", async (t) => {
+  await t.step("string", async (t) => {
+    await assertSnapshot(t, inspect("hello world"));
+  });
+  await t.step("number", async (t) => {
+    await assertSnapshot(t, inspect(100));
+  });
+  await t.step("bigint", async (t) => {
+    await assertSnapshot(t, inspect(100n));
+  });
+  await t.step("boolean", async (t) => {
+    await assertSnapshot(t, inspect(true));
+  });
+  await t.step("array", async (t) => {
+    await assertSnapshot(t, inspect([]));
+    await assertSnapshot(t, inspect([0, 1, 2]));
+    await assertSnapshot(t, inspect([0, "a", true]));
+    await assertSnapshot(t, inspect([0, [1, [2]]]));
+  });
+  await t.step("record", async (t) => {
+    await assertSnapshot(t, inspect({}));
+    await assertSnapshot(t, inspect({ a: 0, b: 1, c: 2 }));
+    await assertSnapshot(t, inspect({ a: "a", b: 1, c: true }));
+    await assertSnapshot(t, inspect({ a: { b: { c: 0 } } }));
+  });
+  await t.step("function", async (t) => {
+    await assertSnapshot(t, inspect(inspect));
+    await assertSnapshot(t, inspect(() => {}));
+  });
+  await t.step("null", async (t) => {
+    await assertSnapshot(t, inspect(null));
+  });
+  await t.step("undefined", async (t) => {
+    await assertSnapshot(t, inspect(undefined));
+  });
+  await t.step("symbol", async (t) => {
+    await assertSnapshot(t, inspect(Symbol("a")));
+  });
+  await t.step("date", async (t) => {
+    await assertSnapshot(t, inspect(new Date()));
+  });
+  await t.step("promise", async (t) => {
+    await assertSnapshot(t, inspect(new Promise(() => {})));
+  });
+});

--- a/is.ts
+++ b/is.ts
@@ -1,3 +1,5 @@
+import { inspect } from "./inspect.ts";
+
 /**
  * A type predicate function
  */
@@ -59,7 +61,14 @@ export function isArray(
 export function isArrayOf<T>(
   pred: Predicate<T>,
 ): Predicate<T[]> {
-  return (x: unknown): x is T[] => isArray(x) && x.every(pred);
+  return Object.defineProperties(
+    (x: unknown): x is T[] => isArray(x) && x.every(pred),
+    {
+      name: {
+        get: () => `isArrayOf(${inspect(pred)})`,
+      },
+    },
+  );
 }
 
 export type TupleOf<T extends readonly Predicate<unknown>[]> = {
@@ -87,12 +96,19 @@ export type TupleOf<T extends readonly Predicate<unknown>[]> = {
 export function isTupleOf<T extends readonly Predicate<unknown>[]>(
   predTup: T,
 ): Predicate<TupleOf<T>> {
-  return (x: unknown): x is TupleOf<T> => {
-    if (!isArray(x) || x.length !== predTup.length) {
-      return false;
-    }
-    return predTup.every((pred, i) => pred(x[i]));
-  };
+  return Object.defineProperties(
+    (x: unknown): x is TupleOf<T> => {
+      if (!isArray(x) || x.length !== predTup.length) {
+        return false;
+      }
+      return predTup.every((pred, i) => pred(x[i]));
+    },
+    {
+      name: {
+        get: () => `isTupleOf(${inspect(predTup)})`,
+      },
+    },
+  );
 }
 
 // https://stackoverflow.com/a/71700658/1273406
@@ -122,10 +138,17 @@ export type UniformTupleOf<
  */
 export function isUniformTupleOf<T, N extends number>(
   n: N,
-  pred: Predicate<T> = (_x: unknown): _x is T => true,
+  pred: Predicate<T> = isAny,
 ): Predicate<UniformTupleOf<T, N>> {
-  const predTup = Array(n).fill(pred);
-  return isTupleOf(predTup) as Predicate<UniformTupleOf<T, N>>;
+  const predInner = isTupleOf(Array(n).fill(pred));
+  return Object.defineProperties(
+    (x: unknown): x is UniformTupleOf<T, N> => predInner(x),
+    {
+      name: {
+        get: () => `isUniformTupleOf(${n}, ${inspect(pred)})`,
+      },
+    },
+  );
 }
 
 /**
@@ -151,13 +174,20 @@ export function isRecord(
 export function isRecordOf<T>(
   pred: Predicate<T>,
 ): Predicate<RecordOf<T>> {
-  return (x: unknown): x is RecordOf<T> => {
-    if (!isRecord(x)) return false;
-    for (const k in x) {
-      if (!pred(x[k])) return false;
-    }
-    return true;
-  };
+  return Object.defineProperties(
+    (x: unknown): x is RecordOf<T> => {
+      if (!isRecord(x)) return false;
+      for (const k in x) {
+        if (!pred(x[k])) return false;
+      }
+      return true;
+    },
+    {
+      name: {
+        get: () => `isRecordOf(${inspect(pred)})`,
+      },
+    },
+  );
 }
 
 type FlatType<T> = T extends RecordOf<unknown>
@@ -204,9 +234,16 @@ export function isObjectOf<
   T extends RecordOf<Predicate<unknown>>,
 >(
   predObj: T,
-  options: { strict?: boolean } = {},
+  { strict }: { strict?: boolean } = {},
 ): Predicate<ObjectOf<T>> {
-  return options.strict ? isObjectOfStrict(predObj) : isObjectOfLoose(predObj);
+  return Object.defineProperties(
+    strict ? isObjectOfStrict(predObj) : isObjectOfLoose(predObj),
+    {
+      name: {
+        get: () => `isObjectOf(${inspect(predObj)})`,
+      },
+    },
+  );
 }
 
 function isObjectOfLoose<
@@ -261,7 +298,14 @@ export function isFunction(x: unknown): x is (...args: unknown[]) => unknown {
 export function isInstanceOf<T extends new (...args: any) => unknown>(
   ctor: T,
 ): Predicate<InstanceType<T>> {
-  return (x: unknown): x is InstanceType<T> => x instanceof ctor;
+  return Object.defineProperties(
+    (x: unknown): x is InstanceType<T> => x instanceof ctor,
+    {
+      name: {
+        get: () => `isInstanceOf(${inspect(ctor)})`,
+      },
+    },
+  );
 }
 
 /**
@@ -312,8 +356,15 @@ export function isPrimitive(x: unknown): x is Primitive {
 /**
  * Return a type predicate function that returns `true` if the type of `x` is a literal type of `pred`.
  */
-export function isLiteralOf<T extends Primitive>(pred: T): Predicate<T> {
-  return (x: unknown): x is T => x === pred;
+export function isLiteralOf<T extends Primitive>(literal: T): Predicate<T> {
+  return Object.defineProperties(
+    (x: unknown): x is T => x === literal,
+    {
+      name: {
+        get: () => `isLiteralOf(${inspect(literal)})`,
+      },
+    },
+  );
 }
 
 /**
@@ -329,10 +380,17 @@ export function isLiteralOf<T extends Primitive>(pred: T): Predicate<T> {
  * ```
  */
 export function isLiteralOneOf<T extends readonly Primitive[]>(
-  preds: T,
+  literals: T,
 ): Predicate<T[number]> {
-  return (x: unknown): x is T[number] =>
-    preds.includes(x as unknown as T[number]);
+  return Object.defineProperties(
+    (x: unknown): x is T[number] =>
+      literals.includes(x as unknown as T[number]),
+    {
+      name: {
+        get: () => `isLiteralOneOf(${inspect(literals)})`,
+      },
+    },
+  );
 }
 
 export type OneOf<T> = T extends Predicate<infer U>[] ? U : never;
@@ -354,7 +412,14 @@ export type OneOf<T> = T extends Predicate<infer U>[] ? U : never;
 export function isOneOf<T extends readonly Predicate<unknown>[]>(
   preds: T,
 ): Predicate<OneOf<T>> {
-  return (x: unknown): x is OneOf<T> => preds.some((pred) => pred(x));
+  return Object.defineProperties(
+    (x: unknown): x is OneOf<T> => preds.some((pred) => pred(x)),
+    {
+      name: {
+        get: () => `isOneOf(${inspect(preds)})`,
+      },
+    },
+  );
 }
 
 type UnionToIntersection<U> =
@@ -380,7 +445,14 @@ export type AllOf<T> = UnionToIntersection<OneOf<T>>;
 export function isAllOf<T extends readonly Predicate<unknown>[]>(
   preds: T,
 ): Predicate<AllOf<T>> {
-  return (x: unknown): x is AllOf<T> => preds.every((pred) => pred(x));
+  return Object.defineProperties(
+    (x: unknown): x is AllOf<T> => preds.every((pred) => pred(x)),
+    {
+      name: {
+        get: () => `isAllOf(${inspect(preds)})`,
+      },
+    },
+  );
 }
 
 export type OptionalPredicate<T> = Predicate<T | undefined> & {
@@ -403,10 +475,15 @@ export type OptionalPredicate<T> = Predicate<T | undefined> & {
 export function isOptionalOf<T>(
   pred: Predicate<T>,
 ): OptionalPredicate<T> {
-  return Object.assign(
+  return Object.defineProperties(
     (x: unknown): x is Predicate<T | undefined> => isUndefined(x) || pred(x),
     {
-      optional: true as const,
+      optional: {
+        value: true as const,
+      },
+      name: {
+        get: () => `isOptionalOf(${inspect(pred)})`,
+      },
     },
   ) as OptionalPredicate<T>;
 }

--- a/is.ts
+++ b/is.ts
@@ -9,6 +9,14 @@ export type Predicate<T> = (x: unknown) => x is T;
 export type PredicateType<P> = P extends Predicate<infer T> ? T : never;
 
 /**
+ * Always return `true` regardless of the type of `x`.
+ */
+// deno-lint-ignore no-explicit-any
+export function isAny(_x: unknown): _x is any {
+  return true;
+}
+
+/**
  * Return `true` if the type of `x` is `string`.
  */
 export function isString(x: unknown): x is string {
@@ -404,6 +412,7 @@ export function isOptionalOf<T>(
 }
 
 export default {
+  Any: isAny,
   String: isString,
   Number: isNumber,
   BigInt: isBigInt,

--- a/is_test.ts
+++ b/is_test.ts
@@ -8,6 +8,7 @@ import type {
 } from "https://deno.land/std@0.202.0/testing/types.ts";
 import is, {
   isAllOf,
+  isAny,
   isArray,
   isArrayOf,
   isBigInt,
@@ -106,6 +107,25 @@ Deno.test("PredicateType", () => {
       }
     >
   >;
+});
+
+Deno.test("isAny", async (t) => {
+  await testWithExamples(t, isAny, {
+    validExamples: [
+      "string",
+      "number",
+      "bigint",
+      "boolean",
+      "array",
+      "record",
+      "function",
+      "null",
+      "undefined",
+      "symbol",
+      "date",
+      "promise",
+    ],
+  });
 });
 
 Deno.test("isString", async (t) => {

--- a/is_test.ts
+++ b/is_test.ts
@@ -2,6 +2,9 @@ import {
   assertEquals,
   assertStrictEquals,
 } from "https://deno.land/std@0.202.0/assert/mod.ts";
+import {
+  assertSnapshot,
+} from "https://deno.land/std@0.202.0/testing/snapshot.ts";
 import type {
   AssertTrue,
   IsExact,
@@ -149,6 +152,10 @@ Deno.test("isArray", async (t) => {
 });
 
 Deno.test("isArrayOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isArrayOf(isNumber).name);
+    await assertSnapshot(t, isArrayOf((_x): _x is string => false).name);
+  });
   await t.step("returns proper type predicate", () => {
     const a: unknown = [0, 1, 2];
     if (isArrayOf(isNumber)(a)) {
@@ -171,6 +178,15 @@ Deno.test("isArrayOf<T>", async (t) => {
 });
 
 Deno.test("isTupleOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isTupleOf([isNumber, isString, isBoolean]).name);
+    await assertSnapshot(t, isTupleOf([(_x): _x is string => false]).name);
+    // Nested
+    await assertSnapshot(
+      t,
+      isTupleOf([isTupleOf([isTupleOf([isNumber, isString, isBoolean])])]).name,
+    );
+  });
   await t.step("returns proper type predicate", () => {
     const predTup = [isNumber, isString, isBoolean] as const;
     const a: unknown = [0, "a", true];
@@ -202,6 +218,14 @@ Deno.test("isTupleOf<T>", async (t) => {
 });
 
 Deno.test("isUniformTupleOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isUniformTupleOf(3).name);
+    await assertSnapshot(t, isUniformTupleOf(3, isNumber).name);
+    await assertSnapshot(
+      t,
+      isUniformTupleOf(3, (_x): _x is string => false).name,
+    );
+  });
   await t.step("returns proper type predicate", () => {
     const a: unknown = [0, 1, 2, 3, 4];
     if (isUniformTupleOf(5)(a)) {
@@ -240,6 +264,10 @@ Deno.test("isRecord", async (t) => {
 });
 
 Deno.test("isRecordOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isRecordOf(isNumber).name);
+    await assertSnapshot(t, isRecordOf((_x): _x is string => false).name);
+  });
   await t.step("returns proper type predicate", () => {
     const a: unknown = { a: 0 };
     if (isRecordOf(isNumber)(a)) {
@@ -264,6 +292,21 @@ Deno.test("isRecordOf<T>", async (t) => {
 });
 
 Deno.test("isObjectOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(
+      t,
+      isObjectOf({ a: isNumber, b: isString, c: isBoolean }).name,
+    );
+    await assertSnapshot(
+      t,
+      isObjectOf({ a: (_x): _x is string => false }).name,
+    );
+    // Nested
+    await assertSnapshot(
+      t,
+      isObjectOf({ a: isObjectOf({ b: isObjectOf({ c: isBoolean }) }) }).name,
+    );
+  });
   await t.step("returns proper type predicate", () => {
     const predObj = {
       a: isNumber,
@@ -414,6 +457,10 @@ Deno.test("isFunction", async (t) => {
 });
 
 Deno.test("isInstanceOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isInstanceOf(Date).name);
+    await assertSnapshot(t, isInstanceOf(class {}).name);
+  });
   await t.step("returns true on T instance", () => {
     class Cls {}
     assertEquals(isInstanceOf(Cls)(new Cls()), true);
@@ -484,6 +531,15 @@ Deno.test("isPrimitive", async (t) => {
 });
 
 Deno.test("isLiteralOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isLiteralOf("hello").name);
+    await assertSnapshot(t, isLiteralOf(100).name);
+    await assertSnapshot(t, isLiteralOf(100n).name);
+    await assertSnapshot(t, isLiteralOf(true).name);
+    await assertSnapshot(t, isLiteralOf(null).name);
+    await assertSnapshot(t, isLiteralOf(undefined).name);
+    await assertSnapshot(t, isLiteralOf(Symbol("asdf")).name);
+  });
   await t.step("returns proper type predicate", () => {
     const pred = "hello";
     const a: unknown = "hello";
@@ -502,6 +558,9 @@ Deno.test("isLiteralOf<T>", async (t) => {
 });
 
 Deno.test("isLiteralOneOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isLiteralOneOf(["hello", "world"]).name);
+  });
   await t.step("returns proper type predicate", () => {
     const preds = ["hello", "world"] as const;
     const a: unknown = "hello";
@@ -521,6 +580,9 @@ Deno.test("isLiteralOneOf<T>", async (t) => {
 });
 
 Deno.test("isOneOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isOneOf([isNumber, isString, isBoolean]).name);
+  });
   await t.step("returns proper type predicate", () => {
     const preds = [isNumber, isString, isBoolean];
     const a: unknown = [0, "a", true];
@@ -543,6 +605,15 @@ Deno.test("isOneOf<T>", async (t) => {
 });
 
 Deno.test("isAllOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(
+      t,
+      isAllOf([
+        is.ObjectOf({ a: is.Number }),
+        is.ObjectOf({ b: is.String }),
+      ]).name,
+    );
+  });
   await t.step("returns proper type predicate", () => {
     const preds = [
       is.ObjectOf({ a: is.Number }),
@@ -582,6 +653,9 @@ Deno.test("isAllOf<T>", async (t) => {
 });
 
 Deno.test("isOptionalOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isOptionalOf(isNumber).name);
+  });
   await t.step("returns proper type predicate", () => {
     const a: unknown = undefined;
     if (isOptionalOf(isNumber)(a)) {

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -13,6 +13,10 @@ await emptyDir("./npm");
 
 await build({
   typeCheck: false,
+  // XXX:
+  // snapshot tests doesn't work with dnt so we disable tests for now
+  // https://github.com/denoland/dnt/issues/254
+  test: false,
   entryPoints: ["./mod.ts"],
   outDir: "./npm",
   shims: {


### PR DESCRIPTION
### Before

```
error: Uncaught AssertError: Expected a value that satisfies the predicate anonymous predicate, got object: {
  "tile": "Awesome article",
  "body": "This is an awesome article",
  "refs": [
    {
      "name": "Deno",
      "url": "https://deno.land/"
    },
    "https://github.com"
  ]
}
    throw new AssertError(
          ^
    at assert (file:///Users/alisue/ghq/github.com/lambdalisue/deno-unknownutil/util.ts:85:11)
    at file:///Users/alisue/ghq/github.com/lambdalisue/test.ts:22:1
```

### After

```
error: Uncaught AssertError: Expected a value that satisfies the predicate isObjectOf({
  title: isString,
  body: isString,
  refs: isArrayOf(isOneOf([
    isString,
    isObjectOf({
      name: isString,
      url: isString
    })
  ]))
}), got object: {
  "tile": "Awesome article",
  "body": "This is an awesome article",
  "refs": [
    {
      "name": "Deno",
      "url": "https://deno.land/"
    },
    "https://github.com"
  ]
}
    throw new AssertError(
          ^
    at assert (file:///Users/alisue/ghq/github.com/lambdalisue/deno-unknownutil/util.ts:85:11)
    at file:///Users/alisue/ghq/github.com/lambdalisue/test.ts:22:1

```