### PR TITLE
:boom: Improve tuple type handlings

### DIFF
--- a/__snapshots__/is_test.ts.snap
+++ b/__snapshots__/is_test.ts.snap
@@ -1,8 +1,101 @@
 export const snapshot = {};
 
+snapshot[`isObjectOf<T> > returns properly named function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  b: isString,
+  c: isBoolean
+})"
+`;
+
+snapshot[`isObjectOf<T> > returns properly named function 2`] = `"isObjectOf({a: a})"`;
+
+snapshot[`isObjectOf<T> > returns properly named function 3`] = `
+"isObjectOf({
+  a: isObjectOf({
+    b: isObjectOf({c: isBoolean})
+  })
+})"
+`;
+
+snapshot[`isOptionalOf<T> > returns properly named function 1`] = `"isOptionalOf(isNumber)"`;
+
+snapshot[`isAllOf<T> > returns properly named function 1`] = `
+"isAllOf([
+  isObjectOf({a: isNumber}),
+  isObjectOf({b: isString})
+])"
+`;
+
 snapshot[`isArrayOf<T> > returns properly named function 1`] = `"isArrayOf(isNumber)"`;
 
 snapshot[`isArrayOf<T> > returns properly named function 2`] = `"isArrayOf((anonymous))"`;
+
+snapshot[`isInstanceOf<T> > returns properly named function 1`] = `"isInstanceOf(Date)"`;
+
+snapshot[`isInstanceOf<T> > returns properly named function 2`] = `"isInstanceOf((anonymous))"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 1`] = `'isLiteralOf("hello")'`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 2`] = `"isLiteralOf(100)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 3`] = `"isLiteralOf(100n)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 4`] = `"isLiteralOf(true)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 5`] = `"isLiteralOf(null)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 6`] = `"isLiteralOf(undefined)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 7`] = `"isLiteralOf(Symbol(asdf))"`;
+
+snapshot[`isOneOf<T> > returns properly named function 1`] = `
+"isOneOf([
+  isNumber,
+  isString,
+  isBoolean
+])"
+`;
+
+snapshot[`isLiteralOneOf<T> > returns properly named function 1`] = `'isLiteralOneOf(["hello", "world"])'`;
+
+snapshot[`isRecordOf<T> > returns properly named function 1`] = `"isRecordOf(isNumber)"`;
+
+snapshot[`isRecordOf<T> > returns properly named function 2`] = `"isRecordOf((anonymous))"`;
+
+snapshot[`isReadonlyTupleOf<T> > returns properly named function 1`] = `
+"isReadonlyTupleOf([
+  isNumber,
+  isString,
+  isBoolean
+])"
+`;
+
+snapshot[`isReadonlyTupleOf<T> > returns properly named function 2`] = `"isReadonlyTupleOf([(anonymous)])"`;
+
+snapshot[`isReadonlyTupleOf<T> > returns properly named function 3`] = `
+"isReadonlyTupleOf([
+  isReadonlyTupleOf([
+    isReadonlyTupleOf([
+      isNumber,
+      isString,
+      isBoolean
+    ])
+  ])
+])"
+`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 1`] = `"isUniformTupleOf(3, isAny)"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 2`] = `"isUniformTupleOf(3, isNumber)"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 3`] = `"isUniformTupleOf(3, (anonymous))"`;
+
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 1`] = `"isReadonlyUniformTupleOf(3, isAny)"`;
+
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 2`] = `"isReadonlyUniformTupleOf(3, isNumber)"`;
+
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 3`] = `"isReadonlyUniformTupleOf(3, (anonymous))"`;
 
 snapshot[`isTupleOf<T> > returns properly named function 1`] = `
 "isTupleOf([
@@ -25,68 +118,3 @@ snapshot[`isTupleOf<T> > returns properly named function 3`] = `
   ])
 ])"
 `;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 1`] = `"isUniformTupleOf(3, isAny)"`;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 2`] = `"isUniformTupleOf(3, isNumber)"`;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 3`] = `"isUniformTupleOf(3, (anonymous))"`;
-
-snapshot[`isRecordOf<T> > returns properly named function 1`] = `"isRecordOf(isNumber)"`;
-
-snapshot[`isRecordOf<T> > returns properly named function 2`] = `"isRecordOf((anonymous))"`;
-
-snapshot[`isObjectOf<T> > returns properly named function 1`] = `
-"isObjectOf({
-  a: isNumber,
-  b: isString,
-  c: isBoolean
-})"
-`;
-
-snapshot[`isObjectOf<T> > returns properly named function 2`] = `"isObjectOf({a: a})"`;
-
-snapshot[`isObjectOf<T> > returns properly named function 3`] = `
-"isObjectOf({
-  a: isObjectOf({
-    b: isObjectOf({c: isBoolean})
-  })
-})"
-`;
-
-snapshot[`isInstanceOf<T> > returns properly named function 1`] = `"isInstanceOf(Date)"`;
-
-snapshot[`isInstanceOf<T> > returns properly named function 2`] = `"isInstanceOf((anonymous))"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 1`] = `'isLiteralOf("hello")'`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 2`] = `"isLiteralOf(100)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 3`] = `"isLiteralOf(100n)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 4`] = `"isLiteralOf(true)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 5`] = `"isLiteralOf(null)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 6`] = `"isLiteralOf(undefined)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 7`] = `"isLiteralOf(Symbol(asdf))"`;
-
-snapshot[`isLiteralOneOf<T> > returns properly named function 1`] = `'isLiteralOneOf(["hello", "world"])'`;
-
-snapshot[`isOneOf<T> > returns properly named function 1`] = `
-"isOneOf([
-  isNumber,
-  isString,
-  isBoolean
-])"
-`;
-
-snapshot[`isAllOf<T> > returns properly named function 1`] = `
-"isAllOf([
-  isObjectOf({a: isNumber}),
-  isObjectOf({b: isString})
-])"
-`;
-
-snapshot[`isOptionalOf<T> > returns properly named function 1`] = `"isOptionalOf(isNumber)"`;

--- a/__snapshots__/is_test.ts.snap
+++ b/__snapshots__/is_test.ts.snap
@@ -1,5 +1,19 @@
 export const snapshot = {};
 
+snapshot[`isLiteralOf<T> > returns properly named function 1`] = `'isLiteralOf("hello")'`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 2`] = `"isLiteralOf(100)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 3`] = `"isLiteralOf(100n)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 4`] = `"isLiteralOf(true)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 5`] = `"isLiteralOf(null)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 6`] = `"isLiteralOf(undefined)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 7`] = `"isLiteralOf(Symbol(asdf))"`;
+
 snapshot[`isObjectOf<T> > returns properly named function 1`] = `
 "isObjectOf({
   a: isNumber,
@@ -18,7 +32,39 @@ snapshot[`isObjectOf<T> > returns properly named function 3`] = `
 })"
 `;
 
+snapshot[`isTupleOf<T> > returns properly named function 1`] = `
+"isTupleOf([
+  isNumber,
+  isString,
+  isBoolean
+])"
+`;
+
+snapshot[`isTupleOf<T> > returns properly named function 2`] = `"isTupleOf([(anonymous)])"`;
+
+snapshot[`isTupleOf<T> > returns properly named function 3`] = `
+"isTupleOf([
+  isTupleOf([
+    isTupleOf([
+      isNumber,
+      isString,
+      isBoolean
+    ])
+  ])
+])"
+`;
+
 snapshot[`isOptionalOf<T> > returns properly named function 1`] = `"isOptionalOf(isNumber)"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 1`] = `"isUniformTupleOf(3, isAny)"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 2`] = `"isUniformTupleOf(3, isNumber)"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 3`] = `"isUniformTupleOf(3, (anonymous))"`;
+
+snapshot[`isInstanceOf<T> > returns properly named function 1`] = `"isInstanceOf(Date)"`;
+
+snapshot[`isInstanceOf<T> > returns properly named function 2`] = `"isInstanceOf((anonymous))"`;
 
 snapshot[`isAllOf<T> > returns properly named function 1`] = `
 "isAllOf([
@@ -27,27 +73,9 @@ snapshot[`isAllOf<T> > returns properly named function 1`] = `
 ])"
 `;
 
-snapshot[`isArrayOf<T> > returns properly named function 1`] = `"isArrayOf(isNumber)"`;
+snapshot[`isRecordOf<T> > returns properly named function 1`] = `"isRecordOf(isNumber)"`;
 
-snapshot[`isArrayOf<T> > returns properly named function 2`] = `"isArrayOf((anonymous))"`;
-
-snapshot[`isInstanceOf<T> > returns properly named function 1`] = `"isInstanceOf(Date)"`;
-
-snapshot[`isInstanceOf<T> > returns properly named function 2`] = `"isInstanceOf((anonymous))"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 1`] = `'isLiteralOf("hello")'`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 2`] = `"isLiteralOf(100)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 3`] = `"isLiteralOf(100n)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 4`] = `"isLiteralOf(true)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 5`] = `"isLiteralOf(null)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 6`] = `"isLiteralOf(undefined)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 7`] = `"isLiteralOf(Symbol(asdf))"`;
+snapshot[`isRecordOf<T> > returns properly named function 2`] = `"isRecordOf((anonymous))"`;
 
 snapshot[`isOneOf<T> > returns properly named function 1`] = `
 "isOneOf([
@@ -59,9 +87,59 @@ snapshot[`isOneOf<T> > returns properly named function 1`] = `
 
 snapshot[`isLiteralOneOf<T> > returns properly named function 1`] = `'isLiteralOneOf(["hello", "world"])'`;
 
-snapshot[`isRecordOf<T> > returns properly named function 1`] = `"isRecordOf(isNumber)"`;
+snapshot[`isTupleOf<T, E> > returns properly named function 1`] = `
+"isTupleOf([
+  isNumber,
+  isString,
+  isBoolean
+], isArray)"
+`;
 
-snapshot[`isRecordOf<T> > returns properly named function 2`] = `"isRecordOf((anonymous))"`;
+snapshot[`isTupleOf<T, E> > returns properly named function 2`] = `"isTupleOf([(anonymous)], isArrayOf(isString))"`;
+
+snapshot[`isTupleOf<T, E> > returns properly named function 3`] = `
+"isTupleOf([
+  isTupleOf([
+    isTupleOf([
+      isNumber,
+      isString,
+      isBoolean
+    ], isArray)
+  ], isArray)
+])"
+`;
+
+snapshot[`isArrayOf<T> > returns properly named function 1`] = `"isArrayOf(isNumber)"`;
+
+snapshot[`isArrayOf<T> > returns properly named function 2`] = `"isArrayOf((anonymous))"`;
+
+snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 1`] = `
+"isReadonlyTupleOf([
+  isNumber,
+  isString,
+  isBoolean
+], isArray)"
+`;
+
+snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 2`] = `"isReadonlyTupleOf([(anonymous)], isArrayOf(isString))"`;
+
+snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 3`] = `
+"isReadonlyTupleOf([
+  isReadonlyTupleOf([
+    isReadonlyTupleOf([
+      isNumber,
+      isString,
+      isBoolean
+    ], isArray)
+  ], isArray)
+], isArray)"
+`;
+
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 1`] = `"isReadonlyUniformTupleOf(3, isAny)"`;
+
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 2`] = `"isReadonlyUniformTupleOf(3, isNumber)"`;
+
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 3`] = `"isReadonlyUniformTupleOf(3, (anonymous))"`;
 
 snapshot[`isReadonlyTupleOf<T> > returns properly named function 1`] = `
 "isReadonlyTupleOf([
@@ -77,40 +155,6 @@ snapshot[`isReadonlyTupleOf<T> > returns properly named function 3`] = `
 "isReadonlyTupleOf([
   isReadonlyTupleOf([
     isReadonlyTupleOf([
-      isNumber,
-      isString,
-      isBoolean
-    ])
-  ])
-])"
-`;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 1`] = `"isUniformTupleOf(3, isAny)"`;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 2`] = `"isUniformTupleOf(3, isNumber)"`;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 3`] = `"isUniformTupleOf(3, (anonymous))"`;
-
-snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 1`] = `"isReadonlyUniformTupleOf(3, isAny)"`;
-
-snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 2`] = `"isReadonlyUniformTupleOf(3, isNumber)"`;
-
-snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 3`] = `"isReadonlyUniformTupleOf(3, (anonymous))"`;
-
-snapshot[`isTupleOf<T> > returns properly named function 1`] = `
-"isTupleOf([
-  isNumber,
-  isString,
-  isBoolean
-])"
-`;
-
-snapshot[`isTupleOf<T> > returns properly named function 2`] = `"isTupleOf([(anonymous)])"`;
-
-snapshot[`isTupleOf<T> > returns properly named function 3`] = `
-"isTupleOf([
-  isTupleOf([
-    isTupleOf([
       isNumber,
       isString,
       isBoolean

--- a/is_bench.ts
+++ b/is_bench.ts
@@ -22,6 +22,24 @@ Deno.bench({
 });
 
 Deno.bench({
+  name: "is.Any",
+  fn: () => {
+    for (const c of cs) {
+      is.Any(c);
+    }
+  },
+});
+
+Deno.bench({
+  name: "is.Unknown",
+  fn: () => {
+    for (const c of cs) {
+      is.Unknown(c);
+    }
+  },
+});
+
+Deno.bench({
   name: "is.String",
   fn: () => {
     for (const c of cs) {
@@ -67,7 +85,7 @@ Deno.bench({
 });
 
 Deno.bench({
-  name: "is.ArrayOf",
+  name: "is.ArrayOf<T>",
   fn: () => {
     const pred = is.ArrayOf(is.String);
     for (const c of cs) {
@@ -78,7 +96,7 @@ Deno.bench({
 
 const isArrayOfPred = is.ArrayOf(is.String);
 Deno.bench({
-  name: "is.ArrayOf (pre)",
+  name: "is.ArrayOf<T> (pre)",
   fn: () => {
     for (const c of cs) {
       isArrayOfPred(c);
@@ -88,7 +106,7 @@ Deno.bench({
 
 const predTup = [is.String, is.Number, is.Boolean] as const;
 Deno.bench({
-  name: "is.TupleOf",
+  name: "is.TupleOf<T>",
   fn: () => {
     const pred = is.TupleOf(predTup);
     for (const c of cs) {
@@ -99,7 +117,7 @@ Deno.bench({
 
 const isTupleOfPred = is.TupleOf(predTup);
 Deno.bench({
-  name: "is.TupleOf (pre)",
+  name: "is.TupleOf<T> (pre)",
   fn: () => {
     for (const c of cs) {
       isTupleOfPred(c);
@@ -108,7 +126,67 @@ Deno.bench({
 });
 
 Deno.bench({
-  name: "is.UniformTupleOf",
+  name: "is.TupleOf<T, E>",
+  fn: () => {
+    const pred = is.TupleOf(predTup, is.Array);
+    for (const c of cs) {
+      pred(c);
+    }
+  },
+});
+
+const isTupleOfElsePred = is.TupleOf(predTup, is.Array);
+Deno.bench({
+  name: "is.TupleOf<T, E> (pre)",
+  fn: () => {
+    for (const c of cs) {
+      isTupleOfElsePred(c);
+    }
+  },
+});
+
+Deno.bench({
+  name: "is.ReadonlyTupleOf<T>",
+  fn: () => {
+    const pred = is.ReadonlyTupleOf(predTup);
+    for (const c of cs) {
+      pred(c);
+    }
+  },
+});
+
+const isReadonlyTupleOfPred = is.ReadonlyTupleOf(predTup);
+Deno.bench({
+  name: "is.ReadonlyTupleOf<T> (pre)",
+  fn: () => {
+    for (const c of cs) {
+      isReadonlyTupleOfPred(c);
+    }
+  },
+});
+
+Deno.bench({
+  name: "is.ReadonlyTupleOf<T, E>",
+  fn: () => {
+    const pred = is.ReadonlyTupleOf(predTup, is.Array);
+    for (const c of cs) {
+      pred(c);
+    }
+  },
+});
+
+const isReadonlyTupleOfElsePred = is.ReadonlyTupleOf(predTup, is.Array);
+Deno.bench({
+  name: "is.ReadonlyTupleOf<T, E> (pre)",
+  fn: () => {
+    for (const c of cs) {
+      isReadonlyTupleOfElsePred(c);
+    }
+  },
+});
+
+Deno.bench({
+  name: "is.UniformTupleOf<N, T>",
   fn: () => {
     const pred = is.UniformTupleOf(3, is.String);
     for (const c of cs) {
@@ -119,10 +197,30 @@ Deno.bench({
 
 const isUniformTupleOfPred = is.UniformTupleOf(3, is.String);
 Deno.bench({
-  name: "is.UniformTupleOf (pre)",
+  name: "is.UniformTupleOf<N, T> (pre)",
   fn: () => {
     for (const c of cs) {
       isUniformTupleOfPred(c);
+    }
+  },
+});
+
+Deno.bench({
+  name: "is.ReadonlyUniformTupleOf<N, T>",
+  fn: () => {
+    const pred = is.ReadonlyUniformTupleOf(3, is.String);
+    for (const c of cs) {
+      pred(c);
+    }
+  },
+});
+
+const isReadonlyUniformTupleOfPred = is.ReadonlyUniformTupleOf(3, is.String);
+Deno.bench({
+  name: "is.ReadonlyUniformTupleOf<N, T> (pre)",
+  fn: () => {
+    for (const c of cs) {
+      isReadonlyUniformTupleOfPred(c);
     }
   },
 });
@@ -137,7 +235,7 @@ Deno.bench({
 });
 
 Deno.bench({
-  name: "is.RecordOf",
+  name: "is.RecordOf<T>",
   fn: () => {
     const pred = is.RecordOf(is.String);
     for (const c of cs) {
@@ -148,7 +246,7 @@ Deno.bench({
 
 const isRecordOfPred = is.RecordOf(is.String);
 Deno.bench({
-  name: "is.RecordOf (pre)",
+  name: "is.RecordOf<T> (pre)",
   fn: () => {
     for (const c of cs) {
       isRecordOfPred(c);
@@ -162,7 +260,7 @@ const predObj = {
   c: is.Boolean,
 } as const;
 Deno.bench({
-  name: "is.ObjectOf",
+  name: "is.ObjectOf<T>",
   fn: () => {
     const pred = is.ObjectOf(predObj);
     for (const c of cs) {
@@ -171,7 +269,7 @@ Deno.bench({
   },
 });
 Deno.bench({
-  name: "is.ObjectOf (strict)",
+  name: "is.ObjectOf<T> (strict)",
   fn: () => {
     const pred = is.ObjectOf(predObj, { strict: true });
     for (const c of cs) {
@@ -182,7 +280,7 @@ Deno.bench({
 
 const isObjectOfPred = is.ObjectOf(predObj);
 Deno.bench({
-  name: "is.ObjectOf (pre)",
+  name: "is.ObjectOf<T> (pre)",
   fn: () => {
     for (const c of cs) {
       isObjectOfPred(c);
@@ -192,7 +290,7 @@ Deno.bench({
 
 const isObjectOfStrictPred = is.ObjectOf(predObj, { strict: true });
 Deno.bench({
-  name: "is.ObjectOf (pre, strict)",
+  name: "is.ObjectOf<T> (pre, strict)",
   fn: () => {
     for (const c of cs) {
       isObjectOfStrictPred(c);
@@ -210,7 +308,25 @@ Deno.bench({
 });
 
 Deno.bench({
-  name: "is.InstanceOf",
+  name: "is.SyncFunction",
+  fn: () => {
+    for (const c of cs) {
+      is.SyncFunction(c);
+    }
+  },
+});
+
+Deno.bench({
+  name: "is.AsyncFunction",
+  fn: () => {
+    for (const c of cs) {
+      is.AsyncFunction(c);
+    }
+  },
+});
+
+Deno.bench({
+  name: "is.InstanceOf<T>",
   fn: () => {
     const pred = is.InstanceOf(Date);
     for (const c of cs) {
@@ -221,7 +337,7 @@ Deno.bench({
 
 const isInstanceOfPred = is.InstanceOf(Date);
 Deno.bench({
-  name: "is.InstanceOf (pre)",
+  name: "is.InstanceOf<T> (pre)",
   fn: () => {
     for (const c of cs) {
       isInstanceOfPred(c);
@@ -276,7 +392,7 @@ Deno.bench({
 
 const predLiteral = "hello";
 Deno.bench({
-  name: "is.LiteralOf",
+  name: "is.LiteralOf<T>",
   fn: () => {
     const pred = is.LiteralOf(predLiteral);
     for (const c of cs) {
@@ -287,7 +403,7 @@ Deno.bench({
 
 const isLiteralOfPred = is.LiteralOf(predLiteral);
 Deno.bench({
-  name: "is.LiteralOf (pre)",
+  name: "is.LiteralOf<T> (pre)",
   fn: () => {
     for (const c of cs) {
       isLiteralOfPred(c);
@@ -297,7 +413,7 @@ Deno.bench({
 
 const predLiteralOne = ["hello", "world"] as const;
 Deno.bench({
-  name: "is.LiteralOneOf",
+  name: "is.LiteralOneOf<T>",
   fn: () => {
     const pred = is.LiteralOneOf(predLiteralOne);
     for (const c of cs) {
@@ -308,7 +424,7 @@ Deno.bench({
 
 const isLiteralOneOfPred = is.LiteralOneOf(predLiteralOne);
 Deno.bench({
-  name: "is.LiteralOneOf (pre)",
+  name: "is.LiteralOneOf<T> (pre)",
   fn: () => {
     for (const c of cs) {
       isLiteralOneOfPred(c);
@@ -318,7 +434,7 @@ Deno.bench({
 
 const predsOne = [is.String, is.Number, is.Boolean] as const;
 Deno.bench({
-  name: "is.OneOf",
+  name: "is.OneOf<T>",
   fn: () => {
     const pred = is.OneOf(predsOne);
     for (const c of cs) {
@@ -329,7 +445,7 @@ Deno.bench({
 
 const isOneOfPred = is.OneOf(predsOne);
 Deno.bench({
-  name: "is.OneOf (pre)",
+  name: "is.OneOf<T> (pre)",
   fn: () => {
     for (const c of cs) {
       isOneOfPred(c);
@@ -339,7 +455,7 @@ Deno.bench({
 
 const predsAll = [is.String, is.Number, is.Boolean] as const;
 Deno.bench({
-  name: "is.AllOf",
+  name: "is.AllOf<T>",
   fn: () => {
     const pred = is.AllOf(predsAll);
     for (const c of cs) {
@@ -350,7 +466,7 @@ Deno.bench({
 
 const isAllOfPred = is.AllOf(predsAll);
 Deno.bench({
-  name: "is.AllOf (pre)",
+  name: "is.AllOf<T> (pre)",
   fn: () => {
     for (const c of cs) {
       isAllOfPred(c);
@@ -359,7 +475,7 @@ Deno.bench({
 });
 
 Deno.bench({
-  name: "is.OptionalOf",
+  name: "is.OptionalOf<T>",
   fn: () => {
     const pred = is.OptionalOf(is.String);
     for (const c of cs) {
@@ -370,7 +486,7 @@ Deno.bench({
 
 const isOptionalOfPred = is.OptionalOf(is.String);
 Deno.bench({
-  name: "is.OptionalOf (pre)",
+  name: "is.OptionalOf<T> (pre)",
   fn: () => {
     for (const c of cs) {
       isOptionalOfPred(c);

--- a/is_test.ts
+++ b/is_test.ts
@@ -28,6 +28,8 @@ import is, {
   isOneOf,
   isOptionalOf,
   isPrimitive,
+  isReadonlyTupleOf,
+  isReadonlyUniformTupleOf,
   isRecord,
   isRecordOf,
   isString,
@@ -217,7 +219,7 @@ Deno.test("isTupleOf<T>", async (t) => {
     const a: unknown = [0, "a", true];
     if (isTupleOf(predTup)(a)) {
       type _ = AssertTrue<
-        IsExact<typeof a, readonly [number, string, boolean]>
+        IsExact<typeof a, [number, string, boolean]>
       >;
     }
   });
@@ -242,6 +244,58 @@ Deno.test("isTupleOf<T>", async (t) => {
   });
 });
 
+Deno.test("isReadonlyTupleOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(
+      t,
+      isReadonlyTupleOf([isNumber, isString, isBoolean]).name,
+    );
+    await assertSnapshot(
+      t,
+      isReadonlyTupleOf([(_x): _x is string => false]).name,
+    );
+    // Nested
+    await assertSnapshot(
+      t,
+      isReadonlyTupleOf([
+        isReadonlyTupleOf([isReadonlyTupleOf([isNumber, isString, isBoolean])]),
+      ]).name,
+    );
+  });
+  await t.step("returns proper type predicate", () => {
+    const predTup = [isNumber, isString, isBoolean] as const;
+    const a: unknown = [0, "a", true];
+    if (isReadonlyTupleOf(predTup)(a)) {
+      type _ = AssertTrue<
+        IsExact<typeof a, readonly [number, string, boolean]>
+      >;
+    }
+  });
+  await t.step("returns true on T tuple", () => {
+    const predTup = [isNumber, isString, isBoolean] as const;
+    assertEquals(isReadonlyTupleOf(predTup)([0, "a", true]), true);
+    assertEquals(isReadonlyTupleOf([])([]), true, "Specify empty predicates");
+  });
+  await t.step("returns false on non T tuple", () => {
+    const predTup = [isNumber, isString, isBoolean] as const;
+    assertEquals(isReadonlyTupleOf(predTup)([0, 1, 2]), false);
+    assertEquals(isReadonlyTupleOf(predTup)([0, "a"]), false);
+    assertEquals(isReadonlyTupleOf(predTup)([0, "a", true, 0]), false);
+    assertEquals(
+      isReadonlyTupleOf([])([0]),
+      false,
+      "Specify empty predicates and value has entry",
+    );
+  });
+  await testWithExamples(
+    t,
+    isReadonlyTupleOf([(_: unknown): _ is unknown => true]),
+    {
+      excludeExamples: ["array"],
+    },
+  );
+});
+
 Deno.test("isUniformTupleOf<T>", async (t) => {
   await t.step("returns properly named function", async (t) => {
     await assertSnapshot(t, isUniformTupleOf(3).name);
@@ -257,14 +311,14 @@ Deno.test("isUniformTupleOf<T>", async (t) => {
       type _ = AssertTrue<
         IsExact<
           typeof a,
-          readonly [unknown, unknown, unknown, unknown, unknown]
+          [unknown, unknown, unknown, unknown, unknown]
         >
       >;
     }
 
     if (isUniformTupleOf(5, isNumber)(a)) {
       type _ = AssertTrue<
-        IsExact<typeof a, readonly [number, number, number, number, number]>
+        IsExact<typeof a, [number, number, number, number, number]>
       >;
     }
   });
@@ -278,6 +332,49 @@ Deno.test("isUniformTupleOf<T>", async (t) => {
     assertEquals(isUniformTupleOf(3, is.Number)(["a", "b", "c"]), false);
   });
   await testWithExamples(t, isUniformTupleOf(4), {
+    excludeExamples: ["array"],
+  });
+});
+
+Deno.test("isReadonlyUniformTupleOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isReadonlyUniformTupleOf(3).name);
+    await assertSnapshot(t, isReadonlyUniformTupleOf(3, isNumber).name);
+    await assertSnapshot(
+      t,
+      isReadonlyUniformTupleOf(3, (_x): _x is string => false).name,
+    );
+  });
+  await t.step("returns proper type predicate", () => {
+    const a: unknown = [0, 1, 2, 3, 4];
+    if (isReadonlyUniformTupleOf(5)(a)) {
+      type _ = AssertTrue<
+        IsExact<
+          typeof a,
+          readonly [unknown, unknown, unknown, unknown, unknown]
+        >
+      >;
+    }
+
+    if (isReadonlyUniformTupleOf(5, isNumber)(a)) {
+      type _ = AssertTrue<
+        IsExact<typeof a, readonly [number, number, number, number, number]>
+      >;
+    }
+  });
+  await t.step("returns true on mono-typed T tuple", () => {
+    assertEquals(isReadonlyUniformTupleOf(3)([0, 1, 2]), true);
+    assertEquals(isReadonlyUniformTupleOf(3, is.Number)([0, 1, 2]), true);
+  });
+  await t.step("returns false on non mono-typed T tuple", () => {
+    assertEquals(isReadonlyUniformTupleOf(4)([0, 1, 2]), false);
+    assertEquals(isReadonlyUniformTupleOf(4)([0, 1, 2, 3, 4]), false);
+    assertEquals(
+      isReadonlyUniformTupleOf(3, is.Number)(["a", "b", "c"]),
+      false,
+    );
+  });
+  await testWithExamples(t, isReadonlyUniformTupleOf(4), {
     excludeExamples: ["array"],
   });
 });
@@ -297,7 +394,7 @@ Deno.test("isRecordOf<T>", async (t) => {
     const a: unknown = { a: 0 };
     if (isRecordOf(isNumber)(a)) {
       type _ = AssertTrue<
-        IsExact<typeof a, Record<string | number | symbol, number>>
+        IsExact<typeof a, Record<PropertyKey, number>>
       >;
     }
   });


### PR DESCRIPTION
- :boom: Remove `readonly` from the predicate type of `isTupleOf` and `isReadonlyUniformTupleOf` and add `isReadonlyTupleOf` and `isReadonlyUniformTupleOf` as alternatives
- :+1: Add second argument `predElse` to `isTupleOf` and `isReadonlyTupleOf` to predicate rest types to handle a type like `[number, string, ...string[]]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced type checking capabilities with support for readonly tuples.
  - Introduced benchmarking for various type checking functions.

- **Refactor**
  - Improved existing type predicate functions for better type verification.

- **Tests**
  - Added test cases for new readonly tuple type checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->