### PR TITLE
:+1: Allowed to specify key predicate for `isRecordOf<T, K>`

### DIFF
--- a/__snapshots__/is_test.ts.snap
+++ b/__snapshots__/is_test.ts.snap
@@ -1,5 +1,11 @@
 export const snapshot = {};
 
+snapshot[`isUniformTupleOf<T> > returns properly named function 1`] = `"isUniformTupleOf(3, isAny)"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 2`] = `"isUniformTupleOf(3, isNumber)"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 3`] = `"isUniformTupleOf(3, (anonymous))"`;
+
 snapshot[`isLiteralOf<T> > returns properly named function 1`] = `'isLiteralOf("hello")'`;
 
 snapshot[`isLiteralOf<T> > returns properly named function 2`] = `"isLiteralOf(100)"`;
@@ -14,78 +20,13 @@ snapshot[`isLiteralOf<T> > returns properly named function 6`] = `"isLiteralOf(u
 
 snapshot[`isLiteralOf<T> > returns properly named function 7`] = `"isLiteralOf(Symbol(asdf))"`;
 
-snapshot[`isObjectOf<T> > returns properly named function 1`] = `
-"isObjectOf({
-  a: isNumber,
-  b: isString,
-  c: isBoolean
-})"
-`;
-
-snapshot[`isObjectOf<T> > returns properly named function 2`] = `"isObjectOf({a: a})"`;
-
-snapshot[`isObjectOf<T> > returns properly named function 3`] = `
-"isObjectOf({
-  a: isObjectOf({
-    b: isObjectOf({c: isBoolean})
-  })
-})"
-`;
-
-snapshot[`isTupleOf<T> > returns properly named function 1`] = `
-"isTupleOf([
-  isNumber,
-  isString,
-  isBoolean
-])"
-`;
-
-snapshot[`isTupleOf<T> > returns properly named function 2`] = `"isTupleOf([(anonymous)])"`;
-
-snapshot[`isTupleOf<T> > returns properly named function 3`] = `
-"isTupleOf([
-  isTupleOf([
-    isTupleOf([
-      isNumber,
-      isString,
-      isBoolean
-    ])
-  ])
-])"
-`;
-
-snapshot[`isOptionalOf<T> > returns properly named function 1`] = `"isOptionalOf(isNumber)"`;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 1`] = `"isUniformTupleOf(3, isAny)"`;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 2`] = `"isUniformTupleOf(3, isNumber)"`;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 3`] = `"isUniformTupleOf(3, (anonymous))"`;
-
-snapshot[`isInstanceOf<T> > returns properly named function 1`] = `"isInstanceOf(Date)"`;
-
-snapshot[`isInstanceOf<T> > returns properly named function 2`] = `"isInstanceOf((anonymous))"`;
-
-snapshot[`isAllOf<T> > returns properly named function 1`] = `
-"isAllOf([
-  isObjectOf({a: isNumber}),
-  isObjectOf({b: isString})
-])"
-`;
-
 snapshot[`isRecordOf<T> > returns properly named function 1`] = `"isRecordOf(isNumber)"`;
 
 snapshot[`isRecordOf<T> > returns properly named function 2`] = `"isRecordOf((anonymous))"`;
 
-snapshot[`isOneOf<T> > returns properly named function 1`] = `
-"isOneOf([
-  isNumber,
-  isString,
-  isBoolean
-])"
-`;
+snapshot[`isRecordOf<T, K> > returns properly named function 1`] = `"isRecordOf(isNumber, isString)"`;
 
-snapshot[`isLiteralOneOf<T> > returns properly named function 1`] = `'isLiteralOneOf(["hello", "world"])'`;
+snapshot[`isRecordOf<T, K> > returns properly named function 2`] = `"isRecordOf((anonymous), isString)"`;
 
 snapshot[`isTupleOf<T, E> > returns properly named function 1`] = `
 "isTupleOf([
@@ -109,9 +50,22 @@ snapshot[`isTupleOf<T, E> > returns properly named function 3`] = `
 ])"
 `;
 
-snapshot[`isArrayOf<T> > returns properly named function 1`] = `"isArrayOf(isNumber)"`;
+snapshot[`isAllOf<T> > returns properly named function 1`] = `
+"isAllOf([
+  isObjectOf({a: isNumber}),
+  isObjectOf({b: isString})
+])"
+`;
 
-snapshot[`isArrayOf<T> > returns properly named function 2`] = `"isArrayOf((anonymous))"`;
+snapshot[`isOneOf<T> > returns properly named function 1`] = `
+"isOneOf([
+  isNumber,
+  isString,
+  isBoolean
+])"
+`;
+
+snapshot[`isOptionalOf<T> > returns properly named function 1`] = `"isOptionalOf(isNumber)"`;
 
 snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 1`] = `
 "isReadonlyTupleOf([
@@ -135,11 +89,43 @@ snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 3`] = `
 ], isArray)"
 `;
 
+snapshot[`isInstanceOf<T> > returns properly named function 1`] = `"isInstanceOf(Date)"`;
+
+snapshot[`isInstanceOf<T> > returns properly named function 2`] = `"isInstanceOf((anonymous))"`;
+
 snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 1`] = `"isReadonlyUniformTupleOf(3, isAny)"`;
 
 snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 2`] = `"isReadonlyUniformTupleOf(3, isNumber)"`;
 
 snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 3`] = `"isReadonlyUniformTupleOf(3, (anonymous))"`;
+
+snapshot[`isLiteralOneOf<T> > returns properly named function 1`] = `'isLiteralOneOf(["hello", "world"])'`;
+
+snapshot[`isTupleOf<T> > returns properly named function 1`] = `
+"isTupleOf([
+  isNumber,
+  isString,
+  isBoolean
+])"
+`;
+
+snapshot[`isTupleOf<T> > returns properly named function 2`] = `"isTupleOf([(anonymous)])"`;
+
+snapshot[`isTupleOf<T> > returns properly named function 3`] = `
+"isTupleOf([
+  isTupleOf([
+    isTupleOf([
+      isNumber,
+      isString,
+      isBoolean
+    ])
+  ])
+])"
+`;
+
+snapshot[`isArrayOf<T> > returns properly named function 1`] = `"isArrayOf(isNumber)"`;
+
+snapshot[`isArrayOf<T> > returns properly named function 2`] = `"isArrayOf((anonymous))"`;
 
 snapshot[`isReadonlyTupleOf<T> > returns properly named function 1`] = `
 "isReadonlyTupleOf([
@@ -161,4 +147,22 @@ snapshot[`isReadonlyTupleOf<T> > returns properly named function 3`] = `
     ])
   ])
 ])"
+`;
+
+snapshot[`isObjectOf<T> > returns properly named function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  b: isString,
+  c: isBoolean
+})"
+`;
+
+snapshot[`isObjectOf<T> > returns properly named function 2`] = `"isObjectOf({a: a})"`;
+
+snapshot[`isObjectOf<T> > returns properly named function 3`] = `
+"isObjectOf({
+  a: isObjectOf({
+    b: isObjectOf({c: isBoolean})
+  })
+})"
 `;

--- a/is.ts
+++ b/is.ts
@@ -473,7 +473,7 @@ export function isSyncFunction(
  */
 export function isAsyncFunction(
   x: unknown,
-): x is (...args: unknown[]) => unknown {
+): x is (...args: unknown[]) => Promise<unknown> {
   return Object.prototype.toString.call(x) === "[object AsyncFunction]";
 }
 

--- a/is.ts
+++ b/is.ts
@@ -1,17 +1,44 @@
 import { inspect } from "./inspect.ts";
 
 /**
- * A type predicate function
+ * A type predicate function.
  */
 export type Predicate<T> = (x: unknown) => x is T;
 
 /**
- * A type predicated by Predicate<T>
+ * A type predicated by Predicate<T>.
+ *
+ * ```ts
+ * import { is, type PredicateType } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const isPerson = is.ObjectOf({
+ *   name: is.String,
+ *   age: is.Number,
+ *   address: is.OptionalOf(is.String),
+ * });
+ *
+ * type Person = PredicateType<typeof isPerson>;
+ * // Above is equivalent to the following type
+ * // type Person = {
+ * //   name: string;
+ * //   age: number;
+ * //   address: string | undefined;
+ * // };
  */
 export type PredicateType<P> = P extends Predicate<infer T> ? T : never;
 
 /**
- * Always return `true` regardless of the type of `x`.
+ * Assume `x is `any` and always return `true` regardless of the type of `x`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a = "a";
+ * if (is.Any(a)) {
+ *   // a is narrowed to any
+ *   const _: any = a;
+ * }
+ * ```
  */
 // deno-lint-ignore no-explicit-any
 export function isAny(_x: unknown): _x is any {
@@ -19,7 +46,17 @@ export function isAny(_x: unknown): _x is any {
 }
 
 /**
- * Always return `true` regardless of the type of `x`.
+ * Assume `x` is `unknown` and always return `true` regardless of the type of `x`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a = "a";
+ * if (is.Unknown(a)) {
+ *   // a is narrowed to unknown
+ *   const _: unknown = a;
+ * }
+ * ```
  */
 export function isUnknown(_x: unknown): _x is unknown {
   return true;
@@ -27,6 +64,16 @@ export function isUnknown(_x: unknown): _x is unknown {
 
 /**
  * Return `true` if the type of `x` is `string`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = "a";
+ * if (is.String(a)) {
+ *   // a is narrowed to string
+ *   const _: string = a;
+ * }
+ * ```
  */
 export function isString(x: unknown): x is string {
   return typeof x === "string";
@@ -34,6 +81,16 @@ export function isString(x: unknown): x is string {
 
 /**
  * Return `true` if the type of `x` is `number`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = 0;
+ * if (is.Number(a)) {
+ *   // a is narrowed to number
+ *   const _: number = a;
+ * }
+ * ```
  */
 export function isNumber(x: unknown): x is number {
   return typeof x === "number";
@@ -41,6 +98,16 @@ export function isNumber(x: unknown): x is number {
 
 /**
  * Return `true` if the type of `x` is `bigint`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = 0n;
+ * if (is.BigInt(a)) {
+ *   // a is narrowed to bigint
+ *   const _: bigint = a;
+ * }
+ * ```
  */
 export function isBigInt(x: unknown): x is bigint {
   return typeof x === "bigint";
@@ -48,6 +115,16 @@ export function isBigInt(x: unknown): x is bigint {
 
 /**
  * Return `true` if the type of `x` is `boolean`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = true;
+ * if (is.Boolean(a)) {
+ *   // a is narrowed to boolean
+ *   const _: boolean = a;
+ * }
+ * ```
  */
 export function isBoolean(x: unknown): x is boolean {
   return typeof x === "boolean";
@@ -55,6 +132,16 @@ export function isBoolean(x: unknown): x is boolean {
 
 /**
  * Return `true` if the type of `x` is `unknown[]`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = [0, 1, 2];
+ * if (is.Array(a)) {
+ *   // a is narrowed to unknown[]
+ *   const _: unknown[] = a;
+ * }
+ * ```
  */
 export function isArray(
   x: unknown,
@@ -64,6 +151,19 @@ export function isArray(
 
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `T[]`.
+ *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const isMyType = is.ArrayOf(is.String);
+ * const a: unknown = ["a", "b", "c"];
+ * if (isMyType(a)) {
+ *   // a is narrowed to string[]
+ *   const _: string[] = a;
+ * }
+ * ```
  */
 export function isArrayOf<T>(
   pred: Predicate<T>,
@@ -78,10 +178,32 @@ export function isArrayOf<T>(
   );
 }
 
+/**
+ * Tuple type of types that are predicated by an array of predicate functions.
+ *
+ * ```ts
+ * import { is, TupleOf } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * type A = TupleOf<readonly [typeof is.String, typeof is.Number]>;
+ * // Above is equivalent to the following type
+ * // type A = [string, number];
+ * ```
+ */
 export type TupleOf<T extends readonly Predicate<unknown>[]> = {
   -readonly [P in keyof T]: T[P] extends Predicate<infer U> ? U : never;
 };
 
+/**
+ * Readonly tuple type of types that are predicated by an array of predicate functions.
+ *
+ * ```ts
+ * import { is, ReadonlyTupleOf } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * type A = ReadonlyTupleOf<readonly [typeof is.String, typeof is.Number]>;
+ * // Above is equivalent to the following type
+ * // type A = readonly [string, number];
+ * ```
+ */
 export type ReadonlyTupleOf<T extends readonly Predicate<unknown>[]> = {
   [P in keyof T]: T[P] extends Predicate<infer U> ? U : never;
 };
@@ -89,14 +211,16 @@ export type ReadonlyTupleOf<T extends readonly Predicate<unknown>[]> = {
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `TupleOf<T>`.
  *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
- * const predTup = [is.Number, is.String, is.Boolean] as const;
+ * const isMyType = is.TupleOf([is.Number, is.String, is.Boolean] as const);
  * const a: unknown = [0, "a", true];
- * if (is.TupleOf(predTup)(a)) {
- *  // a is narrowed to [number, string, boolean]
- *  const _: [number, string, boolean] = a;
+ * if (isMyType(a)) {
+ *   // a is narrowed to [number, string, boolean]
+ *   const _: [number, string, boolean] = a;
  * }
  * ```
  *
@@ -109,12 +233,14 @@ export type ReadonlyTupleOf<T extends readonly Predicate<unknown>[]> = {
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
- * const predTup = [is.Number, is.String, is.Boolean] as const;
- * const predElse = is.ArrayOf(is.Number);
+ * const isMyType = is.TupleOf(
+ *   [is.Number, is.String, is.Boolean] as const,
+ *   is.ArrayOf(is.Number),
+ * );
  * const a: unknown = [0, "a", true, 0, 1, 2];
- * if (is.TupleOf(predTup, predElse)(a)) {
- *  // a is narrowed to [number, string, boolean, ...number[]]
- *  const _: [number, string, boolean, ...number[]] = a;
+ * if (isMyType(a)) {
+ *   // a is narrowed to [number, string, boolean, ...number[]]
+ *   const _: [number, string, boolean, ...number[]] = a;
  * }
  * ```
  */
@@ -177,14 +303,16 @@ export function isTupleOf<
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `ReadonlyTupleOf<T>`.
  *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
- * const predTup = [is.Number, is.String, is.Boolean] as const;
+ * const isMyType = is.ReadonlyTupleOf([is.Number, is.String, is.Boolean] as const);
  * const a: unknown = [0, "a", true];
- * if (is.ReadonlyTupleOf(predTup)(a)) {
- *  // a is narrowed to readonly [number, string, boolean]
- *  const _: readonly [number, string, boolean] = a;
+ * if (isMyType(a)) {
+ *   // a is narrowed to readonly [number, string, boolean]
+ *   const _: readonly [number, string, boolean] = a;
  * }
  * ```
  *
@@ -197,12 +325,14 @@ export function isTupleOf<
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
- * const predTup = [is.Number, is.String, is.Boolean] as const;
- * const predElse = is.ArrayOf(is.Number);
+ * const isMyType = is.ReadonlyTupleOf(
+ *   [is.Number, is.String, is.Boolean] as const,
+ *   is.ArrayOf(is.Number),
+ * );
  * const a: unknown = [0, "a", true, 0, 1, 2];
- * if (is.ReadonlyTupleOf(predTup, predElse)(a)) {
- *  // a is narrowed to readonly [number, string, boolean, ...number[]]
- *  const _: readonly [number, string, boolean, ...number[]] = a;
+ * if (isMyType(a)) {
+ *   // a is narrowed to readonly [number, string, boolean, ...number[]]
+ *   const _: readonly [number, string, boolean, ...number[]] = a;
  * }
  */
 export function isReadonlyTupleOf<
@@ -250,6 +380,17 @@ export function isReadonlyTupleOf<
   }
 }
 
+/**
+ * Uniform tuple type of types that are predicated by a predicate function and the length is `N`.
+ *
+ * ```ts
+ * import { is, UniformTupleOf } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * type A = UniformTupleOf<number, 5>;
+ * // Above is equivalent to the following type
+ * // type A = [number, number, number, number, number];
+ * ```
+ */
 // https://stackoverflow.com/a/71700658/1273406
 export type UniformTupleOf<
   T,
@@ -257,6 +398,17 @@ export type UniformTupleOf<
   R extends readonly T[] = [],
 > = R["length"] extends N ? R : UniformTupleOf<T, N, [T, ...R]>;
 
+/**
+ * Readonly uniform tuple type of types that are predicated by a predicate function `T` and the length is `N`.
+ *
+ * ```ts
+ * import { is, ReadonlyUniformTupleOf } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * type A = ReadonlyUniformTupleOf<number, 5>;
+ * // Above is equivalent to the following type
+ * // type A = readonly [number, number, number, number, number];
+ * ```
+ */
 export type ReadonlyUniformTupleOf<
   T,
   N extends number,
@@ -267,18 +419,29 @@ export type ReadonlyUniformTupleOf<
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `UniformTupleOf<T>`.
  *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
+ * const isMyType = is.UniformTupleOf(5);
  * const a: unknown = [0, 1, 2, 3, 4];
- * if (is.UniformTupleOf(5)(a)) {
- *  // a is narrowed to [unknown, unknown, unknown, unknown, unknown]
- *  const _: [unknown, unknown, unknown, unknown, unknown] = a;
+ * if (isMyType(a)) {
+ *   // a is narrowed to [unknown, unknown, unknown, unknown, unknown]
+ *   const _: [unknown, unknown, unknown, unknown, unknown] = a;
  * }
+ * ```
  *
- * if (is.UniformTupleOf(5, is.Number)(a)) {
- *  // a is narrowed to [number, number, number, number, number]
- *  const _: [number, number, number, number, number] = a;
+ * With predicate function:
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const isMyType = is.UniformTupleOf(5, is.Number);
+ * const a: unknown = [0, 1, 2, 3, 4];
+ * if (isMyType(a)) {
+ *   // a is narrowed to [number, number, number, number, number]
+ *   const _: [number, number, number, number, number] = a;
  * }
  * ```
  */
@@ -300,18 +463,29 @@ export function isUniformTupleOf<T, N extends number>(
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `ReadonlyUniformTupleOf<T>`.
  *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
+ * const isMyType = is.ReadonlyUniformTupleOf(5);
  * const a: unknown = [0, 1, 2, 3, 4];
- * if (is.ReadonlyUniformTupleOf(5)(a)) {
- *  // a is narrowed to readonly [unknown, unknown, unknown, unknown, unknown]
- *  const _: readonly [unknown, unknown, unknown, unknown, unknown] = a;
+ * if (isMyType(a)) {
+ *   // a is narrowed to readonly [unknown, unknown, unknown, unknown, unknown]
+ *   const _: readonly [unknown, unknown, unknown, unknown, unknown] = a;
  * }
+ * ```
  *
- * if (is.ReadonlyUniformTupleOf(5, is.Number)(a)) {
- *  // a is narrowed to readonly [number, number, number, number, number]
- *  const _: readonly [number, number, number, number, number] = a;
+ * With predicate function:
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const isMyType = is.ReadonlyUniformTupleOf(5, is.Number);
+ * const a: unknown = [0, 1, 2, 3, 4];
+ * if (isMyType(a)) {
+ *   // a is narrowed to readonly [number, number, number, number, number]
+ *   const _: readonly [number, number, number, number, number] = a;
  * }
  * ```
  */
@@ -335,11 +509,21 @@ export function isReadonlyUniformTupleOf<T, N extends number>(
 export type RecordOf<T> = Record<PropertyKey, T>;
 
 /**
- * Return `true` if the type of `x` is `RecordOf<unknown>`.
+ * Return `true` if the type of `x` is `Record<PropertyKey, unknown>`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = {"a": 0, "b": 1};
+ * if (is.Record(a)) {
+ *   // a is narrowed to Record<PropertyKey, unknown>
+ *   const _: Record<PropertyKey, unknown> = a;
+ * }
+ * ```
  */
 export function isRecord(
   x: unknown,
-): x is RecordOf<unknown> {
+): x is Record<PropertyKey, unknown> {
   if (isNullish(x) || isArray(x)) {
     return false;
   }
@@ -348,6 +532,19 @@ export function isRecord(
 
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `RecordOf<T>`.
+ *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const isMyType = is.RecordOf(is.Number);
+ * const a: unknown = {"a": 0, "b": 1};
+ * if (isMyType(a)) {
+ *   // a is narrowed to Record<PropertyKey, number>
+ *   const _: Record<PropertyKey, number> = a;
+ * }
+ * ```
  */
 export function isRecordOf<T>(
   pred: Predicate<T>,
@@ -376,6 +573,17 @@ type OptionalPredicateKeys<T extends RecordOf<unknown>> = {
   [K in keyof T]: T[K] extends OptionalPredicate<unknown> ? K : never;
 }[keyof T];
 
+/**
+ * Object types that are predicated by predicate functions in the object `T`.
+ *
+ * ```ts
+ * import { is, ObjectOf } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * type A = ObjectOf<{ a: typeof is.Number, b: typeof is.String }>;
+ * // Above is equivalent to the following type
+ * // type A = { a: number; b: string };
+ * ```
+ */
 export type ObjectOf<T extends RecordOf<Predicate<unknown>>> = FlatType<
   & {
     [K in Exclude<keyof T, OptionalPredicateKeys<T>>]: T[K] extends
@@ -389,22 +597,43 @@ export type ObjectOf<T extends RecordOf<Predicate<unknown>>> = FlatType<
 
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `ObjectOf<T>`.
+ *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
  * If `is.OptionalOf()` is specified in the predicate function, the property becomes optional.
+ *
  * When `options.strict` is `true`, the number of keys of `x` must be equal to the number of keys of `predObj`.
  * Otherwise, the number of keys of `x` must be greater than or equal to the number of keys of `predObj`.
  *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
- * const predObj = {
- *  a: is.Number,
- *  b: is.String,
- *  c: is.OptionalOf(is.Boolean),
- * };
- * const a: unknown = { a: 0, b: "a" };
- * if (is.ObjectOf(predObj)(a)) {
- *  // a is narrowed to { a: number; b: string; c?: boolean }
- *  const _: { a: number; b: string; c?: boolean } = a;
+ * const isMyType = is.ObjectOf({
+ *   a: is.Number,
+ *   b: is.String,
+ *   c: is.OptionalOf(is.Boolean),
+ * });
+ * const a: unknown = { a: 0, b: "a", other: "other" };
+ * if (isMyType(a)) {
+ *   // "other" key in `a` is ignored because of `options.strict` is `false`.
+ *   // a is narrowed to { a: number; b: string; c?: boolean | undefined }
+ *   const _: { a: number; b: string; c?: boolean | undefined } = a;
+ * }
+ * ```
+ *
+ * With `options.strict`:
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const isMyType = is.ObjectOf({
+ *   a: is.Number,
+ *   b: is.String,
+ *   c: is.OptionalOf(is.Boolean),
+ * }, { strict: true });
+ * const a: unknown = { a: 0, b: "a", other: "other" };
+ * if (isMyType(a)) {
+ *   // This block will not be executed because of "other" key in `a`.
  * }
  * ```
  */
@@ -454,6 +683,16 @@ function isObjectOfStrict<
 
 /**
  * Return `true` if the type of `x` is `function`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = () => {};
+ * if (is.Function(a)) {
+ *   // a is narrowed to (...args: unknown[]) => unknown
+ *   const _: ((...args: unknown[]) => unknown) = a;
+ * }
+ * ```
  */
 export function isFunction(x: unknown): x is (...args: unknown[]) => unknown {
   return x instanceof Function;
@@ -461,6 +700,16 @@ export function isFunction(x: unknown): x is (...args: unknown[]) => unknown {
 
 /**
  * Return `true` if the type of `x` is `function` (non async function).
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = () => {};
+ * if (is.Function(a)) {
+ *   // a is narrowed to (...args: unknown[]) => unknown
+ *   const _: ((...args: unknown[]) => unknown) = a;
+ * }
+ * ```
  */
 export function isSyncFunction(
   x: unknown,
@@ -470,6 +719,16 @@ export function isSyncFunction(
 
 /**
  * Return `true` if the type of `x` is `function` (async function).
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = async () => {};
+ * if (is.Function(a)) {
+ *   // a is narrowed to (...args: unknown[]) => Promise<unknown>
+ *   const _: ((...args: unknown[]) => unknown) = a;
+ * }
+ * ```
  */
 export function isAsyncFunction(
   x: unknown,
@@ -480,11 +739,14 @@ export function isAsyncFunction(
 /**
  * Return `true` if the type of `x` is instance of `ctor`.
  *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
+ * const isMyType = is.InstanceOf(Date);
  * const a: unknown = new Date();
- * if (is.InstanceOf(Date)(a)) {
+ * if (isMyType(a)) {
  *   // a is narrowed to Date
  *   const _: Date = a;
  * }
@@ -506,6 +768,16 @@ export function isInstanceOf<T extends new (...args: any) => unknown>(
 
 /**
  * Return `true` if the type of `x` is `null`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = null;
+ * if (is.Null(a)) {
+ *   // a is narrowed to null
+ *   const _: null = a;
+ * }
+ * ```
  */
 export function isNull(x: unknown): x is null {
   return x === null;
@@ -513,6 +785,16 @@ export function isNull(x: unknown): x is null {
 
 /**
  * Return `true` if the type of `x` is `undefined`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = undefined;
+ * if (is.Undefined(a)) {
+ *   // a is narrowed to undefined
+ *   const _: undefined = a;
+ * }
+ * ```
  */
 export function isUndefined(x: unknown): x is undefined {
   return typeof x === "undefined";
@@ -520,6 +802,16 @@ export function isUndefined(x: unknown): x is undefined {
 
 /**
  * Return `true` if the type of `x` is `null` or `undefined`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = null;
+ * if (is.Nullish(a)) {
+ *   // a is narrowed to null | undefined
+ *   const _: (null | undefined) = a;
+ * }
+ * ```
  */
 export function isNullish(x: unknown): x is null | undefined {
   return x == null;
@@ -527,6 +819,16 @@ export function isNullish(x: unknown): x is null | undefined {
 
 /**
  * Return `true` if the type of `x` is `symbol`.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = Symbol("symbol");
+ * if (is.Symbol(a)) {
+ *   // a is narrowed to symbol
+ *   const _: symbol = a;
+ * }
+ * ```
  */
 export function isSymbol(x: unknown): x is symbol {
   return typeof x === "symbol";
@@ -542,7 +844,17 @@ export type Primitive =
   | symbol;
 
 /**
- * Return `true` if the type of `x` is Primitive.
+ * Return `true` if the type of `x` is `Primitive`.
+ *
+ * ```ts
+ * import { is, Primitive } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = 0;
+ * if (is.Primitive(a)) {
+ *   // a is narrowed to Primitive
+ *   const _: Primitive = a;
+ * }
+ * ```
  */
 export function isPrimitive(x: unknown): x is Primitive {
   return x == null ||
@@ -551,6 +863,19 @@ export function isPrimitive(x: unknown): x is Primitive {
 
 /**
  * Return a type predicate function that returns `true` if the type of `x` is a literal type of `pred`.
+ *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const isMyType = is.LiteralOf("hello");
+ * const a: unknown = "hello";
+ * if (isMyType(a)) {
+ *   // a is narrowed to "hello"
+ *   const _: "hello" = a;
+ * }
+ * ```
  */
 export function isLiteralOf<T extends Primitive>(literal: T): Predicate<T> {
   return Object.defineProperties(
@@ -566,13 +891,16 @@ export function isLiteralOf<T extends Primitive>(literal: T): Predicate<T> {
 /**
  * Return a type predicate function that returns `true` if the type of `x` is one of literal type in `preds`.
  *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
+ * const isMyType = is.LiteralOneOf(["hello", "world"] as const);
  * const a: unknown = "hello";
- * if (is.LiteralOneOf(["hello", "world"] as const)(a)) {
- *  // a is narrowed to "hello" | "world"
- *  const _: "hello" | "world" = a;
+ * if (isMyType(a)) {
+ *   // a is narrowed to "hello" | "world"
+ *   const _: "hello" | "world" = a;
  * }
  * ```
  */
@@ -595,14 +923,16 @@ export type OneOf<T> = T extends Predicate<infer U>[] ? U : never;
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `OneOf<T>`.
  *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
- * const preds = [is.Number, is.String, is.Boolean];
+ * const isMyType = is.OneOf([is.Number, is.String, is.Boolean]);
  * const a: unknown = 0;
- * if (is.OneOf(preds)(a)) {
- *  // a is narrowed to number | string | boolean
- *  const _: number | string | boolean = a;
+ * if (isMyType(a)) {
+ *   // a is narrowed to number | string | boolean
+ *   const _: number | string | boolean = a;
  * }
  * ```
  */
@@ -628,14 +958,19 @@ export type AllOf<T> = UnionToIntersection<OneOf<T>>;
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `AllOf<T>`.
  *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
- * const preds = [is.ObjectOf({ a: is.Number }), is.ObjectOf({ b: is.String })];
+ * const isMyType = is.AllOf([
+ *   is.ObjectOf({ a: is.Number }),
+ *   is.ObjectOf({ b: is.String }),
+ * ]);
  * const a: unknown = { a: 0, b: "a" };
- * if (is.AllOf(preds)(a)) {
- *  // a is narrowed to { a: number; b: string }
- *  const _: { a: number; b: string } = a;
+ * if (isMyType(a)) {
+ *   // a is narrowed to { a: number; b: string }
+ *   const _: { a: number; b: string } = a;
  * }
  * ```
  */
@@ -659,13 +994,16 @@ export type OptionalPredicate<T> = Predicate<T | undefined> & {
 /**
  * Return a type predicate function that returns `true` if the type of `x` is `T` or `undefined`.
  *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
+ * const isMyType = is.OptionalOf(is.String);
  * const a: unknown = "a";
- * if (is.OptionalOf(is.String)(a)) {
- *  // a is narrowed to string | undefined
- *  const _: string | undefined = a;
+ * if (isMyType(a)) {
+ *   // a is narrowed to string | undefined
+ *   const _: string | undefined = a;
  * }
  * ```
  */

--- a/is_test.ts
+++ b/is_test.ts
@@ -635,6 +635,42 @@ Deno.test("isRecordOf<T>", async (t) => {
   });
 });
 
+Deno.test("isRecordOf<T, K>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isRecordOf(isNumber, isString).name);
+    await assertSnapshot(
+      t,
+      isRecordOf((_x): _x is string => false, isString).name,
+    );
+  });
+  await t.step("returns proper type predicate", () => {
+    const a: unknown = { a: 0 };
+    if (isRecordOf(isNumber, isString)(a)) {
+      type _ = AssertTrue<
+        IsExact<typeof a, Record<string, number>>
+      >;
+    }
+  });
+  await t.step("returns true on T record", () => {
+    assertEquals(isRecordOf(isNumber, isString)({ a: 0 }), true);
+    assertEquals(isRecordOf(isString, isString)({ a: "a" }), true);
+    assertEquals(isRecordOf(isBoolean, isString)({ a: true }), true);
+  });
+  await t.step("returns false on non T record", () => {
+    assertEquals(isRecordOf(isString, isString)({ a: 0 }), false);
+    assertEquals(isRecordOf(isNumber, isString)({ a: "a" }), false);
+    assertEquals(isRecordOf(isString, isString)({ a: true }), false);
+  });
+  await t.step("returns false on non K record", () => {
+    assertEquals(isRecordOf(isNumber, isNumber)({ a: 0 }), false);
+    assertEquals(isRecordOf(isString, isNumber)({ a: "a" }), false);
+    assertEquals(isRecordOf(isBoolean, isNumber)({ a: true }), false);
+  });
+  await testWithExamples(t, isRecordOf((_: unknown): _ is unknown => true), {
+    excludeExamples: ["record", "date", "promise"],
+  });
+});
+
 Deno.test("ObjectOf<T>", () => {
   type _ = AssertTrue<
     IsExact<

--- a/is_test.ts
+++ b/is_test.ts
@@ -39,8 +39,13 @@ import is, {
   isUndefined,
   isUniformTupleOf,
   isUnknown,
+  ObjectOf,
   Predicate,
   PredicateType,
+  ReadonlyTupleOf,
+  ReadonlyUniformTupleOf,
+  TupleOf,
+  UniformTupleOf,
 } from "./is.ts";
 
 const examples = {
@@ -202,6 +207,24 @@ Deno.test("isArrayOf<T>", async (t) => {
   await testWithExamples(t, isArrayOf((_: unknown): _ is unknown => true), {
     excludeExamples: ["array"],
   });
+});
+
+Deno.test("TupleOf<T>", () => {
+  type _ = AssertTrue<
+    IsExact<
+      TupleOf<readonly [typeof is.String, typeof is.Number]>,
+      [string, number]
+    >
+  >;
+});
+
+Deno.test("ReadonlyTupleOf<T>", () => {
+  type _ = AssertTrue<
+    IsExact<
+      ReadonlyTupleOf<readonly [typeof is.String, typeof is.Number]>,
+      readonly [string, number]
+    >
+  >;
 });
 
 Deno.test("isTupleOf<T>", async (t) => {
@@ -477,6 +500,24 @@ Deno.test("isReadonlyTupleOf<T, E>", async (t) => {
   );
 });
 
+Deno.test("UniformTupleOf<N, T>", () => {
+  type _ = AssertTrue<
+    IsExact<
+      UniformTupleOf<number, 5>,
+      [number, number, number, number, number]
+    >
+  >;
+});
+
+Deno.test("ReadonlyUniformTupleOf<N, T>", () => {
+  type _ = AssertTrue<
+    IsExact<
+      ReadonlyUniformTupleOf<number, 5>,
+      readonly [number, number, number, number, number]
+    >
+  >;
+});
+
 Deno.test("isUniformTupleOf<T>", async (t) => {
   await t.step("returns properly named function", async (t) => {
     await assertSnapshot(t, isUniformTupleOf(3).name);
@@ -592,6 +633,15 @@ Deno.test("isRecordOf<T>", async (t) => {
   await testWithExamples(t, isRecordOf((_: unknown): _ is unknown => true), {
     excludeExamples: ["record", "date", "promise"],
   });
+});
+
+Deno.test("ObjectOf<T>", () => {
+  type _ = AssertTrue<
+    IsExact<
+      ObjectOf<{ a: typeof is.Number; b: typeof is.String }>,
+      { a: number; b: string }
+    >
+  >;
 });
 
 Deno.test("isObjectOf<T>", async (t) => {

--- a/is_test.ts
+++ b/is_test.ts
@@ -759,18 +759,33 @@ Deno.test("isFunction", async (t) => {
   await testWithExamples(t, isFunction, {
     validExamples: ["syncFunction", "asyncFunction"],
   });
+  type _ = AssertTrue<
+    IsExact<PredicateType<typeof isFunction>, (...args: unknown[]) => unknown>
+  >;
 });
 
 Deno.test("isSyncFunction", async (t) => {
   await testWithExamples(t, isSyncFunction, {
     validExamples: ["syncFunction"],
   });
+  type _ = AssertTrue<
+    IsExact<
+      PredicateType<typeof isSyncFunction>,
+      (...args: unknown[]) => unknown
+    >
+  >;
 });
 
 Deno.test("isAsyncFunction", async (t) => {
   await testWithExamples(t, isAsyncFunction, {
     validExamples: ["asyncFunction"],
   });
+  type _ = AssertTrue<
+    IsExact<
+      PredicateType<typeof isAsyncFunction>,
+      (...args: unknown[]) => Promise<unknown>
+    >
+  >;
 });
 
 Deno.test("isInstanceOf<T>", async (t) => {


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new type predicate functions to improve type checking.
	- Expanded type checking capabilities with additional type declarations for tuples and records.
- **Documentation**
	- Added examples and performance advice for certain functions.
- **Tests**
	- Implemented tests for new type declarations and predicate functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->