### PR TITLE
:bug: Fix `isObjectOf` for non pure object predication

### DIFF
--- a/is/factory.ts
+++ b/is/factory.ts
@@ -511,7 +511,7 @@ export function isObjectOf<
     .map(([k]) => k);
   return setPredicateFactoryMetadata(
     (x: unknown): x is ObjectOf<T> => {
-      if (!isRecord(x)) return false;
+      if (x == null || typeof x !== "object") return false;
       // Check required keys
       const s = new Set(Object.keys(x));
       if (requiredKeys.some((k) => !s.has(k))) return false;

--- a/is/factory.ts
+++ b/is/factory.ts
@@ -1,6 +1,6 @@
 import type { FlatType } from "../_typeutil.ts";
 import type { Predicate, PredicateType } from "./type.ts";
-import { isOptional, isOptionalOf, isReadonlyOf } from "./annotation.ts";
+import { isOptionalOf, isReadonlyOf } from "./annotation.ts";
 import {
   isAny,
   isArray,
@@ -506,18 +506,12 @@ export function isObjectOf<
     // deno-lint-ignore no-explicit-any
     return isStrictOf(isObjectOf(predObj)) as any;
   }
-  const requiredKeys = Object.entries(predObj)
-    .filter(([_, v]) => !isWithOptional(v))
-    .map(([k]) => k);
   return setPredicateFactoryMetadata(
     (x: unknown): x is ObjectOf<T> => {
       if (x == null || typeof x !== "object") return false;
-      // Check required keys
-      const s = new Set(Object.keys(x));
-      if (requiredKeys.some((k) => !s.has(k))) return false;
       // Check each values
       for (const k in predObj) {
-        if (!predObj[k](x[k])) return false;
+        if (!predObj[k]((x as T)[k])) return false;
       }
       return true;
     },
@@ -528,13 +522,6 @@ export function isObjectOf<
 type WithOptional =
   | WithMetadata<GetMetadata<ReturnType<typeof isOptionalOf>>>
   | { optional: true }; // For backward compatibility
-
-function isWithOptional<T extends Predicate<unknown>>(
-  pred: T,
-): pred is T & WithOptional {
-  // deno-lint-ignore no-explicit-any
-  return isOptional(pred) || (pred as any).optional === true;
-}
 
 type ObjectOf<T extends Record<PropertyKey, Predicate<unknown>>> = FlatType<
   // Non optional

--- a/is/factory_test.ts
+++ b/is/factory_test.ts
@@ -9,7 +9,14 @@ import { assertType } from "https://deno.land/std@0.211.0/testing/types.ts";
 import { type Equal, stringify } from "./_testutil.ts";
 import { type Predicate } from "./type.ts";
 import { isOptionalOf } from "./annotation.ts";
-import { isArray, isBoolean, isNumber, isString, isUndefined } from "./core.ts";
+import {
+  isArray,
+  isBoolean,
+  isFunction,
+  isNumber,
+  isString,
+  isUndefined,
+} from "./core.ts";
 import is, {
   isArrayOf,
   isInstanceOf,
@@ -611,6 +618,13 @@ Deno.test("isObjectOf<T>", async (t) => {
       false,
       "Specify `{ strict: true }` and object have an unknown property",
     );
+  });
+  await t.step("returns true on T instance", () => {
+    const date = new Date();
+    const predObj = {
+      getFullYear: isFunction,
+    };
+    assertEquals(isObjectOf(predObj)(date), true, "Value is not an object");
   });
   await testWithExamples(
     t,


### PR DESCRIPTION
Prior to v1.6.0, `isObjectOf` supported predicating non pure object like `Date` instance.

This PR add tests for this case and fix the behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced type checking for object properties to improve validation logic.
- **Tests**
	- Added a new test case to validate objects with specific properties more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->