### PR TITLE
👍 Add `isRecordLike` and `isRecordLikeOf`, fix `isObjectOf` that should not allow `Array`

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,7 +5,7 @@
   },
   "tasks": {
     "build-npm": "deno run -A scripts/build_npm.ts $(git describe --tags --always --dirty)",
-    "test": "deno test -A --parallel --shuffle --doc",
+    "test": "deno test -A --parallel --doc",
     "test:coverage": "deno task test --coverage=.coverage",
     "check": "deno check ./**/*.ts",
     "coverage": "deno coverage .coverage --exclude=is_bench.ts",

--- a/is/__snapshots__/_deprecated_test.ts.snap
+++ b/is/__snapshots__/_deprecated_test.ts.snap
@@ -1,16 +1,16 @@
 export const snapshot = {};
 
-snapshot[`isAllOf<T> > returns properly named function 1`] = `
-"isObjectOf({
-  a: isNumber,
-  b: isString
-})"
-`;
-
 snapshot[`isOneOf<T> > returns properly named function 1`] = `
 "isUnionOf([
   isNumber,
   isString,
   isBoolean
 ])"
+`;
+
+snapshot[`isAllOf<T> > returns properly named function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  b: isString
+})"
 `;

--- a/is/__snapshots__/annotation_test.ts.snap
+++ b/is/__snapshots__/annotation_test.ts.snap
@@ -1,19 +1,19 @@
 export const snapshot = {};
 
-snapshot[`isOptionalOf<T> > returns properly named function 1`] = `"isOptionalOf(isNumber)"`;
-
-snapshot[`isOptionalOf<T> > returns properly named function 2`] = `"isOptionalOf(isNumber)"`;
-
 snapshot[`isUnwrapOptionalOf<T> > returns properly named function 1`] = `"isNumber"`;
 
 snapshot[`isUnwrapOptionalOf<T> > returns properly named function 2`] = `"isNumber"`;
 
 snapshot[`isUnwrapOptionalOf<T> > returns properly named function 3`] = `"isNumber"`;
 
+snapshot[`isReadonlyOf<T> > returns properly named function 1`] = `"isReadonlyOf(isNumber)"`;
+
+snapshot[`isReadonlyOf<T> > returns properly named function 2`] = `"isReadonlyOf(isReadonlyOf(isNumber))"`;
+
 snapshot[`isUnwrapReadonlyOf<T> > returns properly named function 1`] = `"isNumber"`;
 
 snapshot[`isUnwrapReadonlyOf<T> > returns properly named function 2`] = `"isReadonlyOf(isNumber)"`;
 
-snapshot[`isReadonlyOf<T> > returns properly named function 1`] = `"isReadonlyOf(isNumber)"`;
+snapshot[`isOptionalOf<T> > returns properly named function 1`] = `"isOptionalOf(isNumber)"`;
 
-snapshot[`isReadonlyOf<T> > returns properly named function 2`] = `"isReadonlyOf(isReadonlyOf(isNumber))"`;
+snapshot[`isOptionalOf<T> > returns properly named function 2`] = `"isOptionalOf(isNumber)"`;

--- a/is/__snapshots__/annotation_test.ts.snap
+++ b/is/__snapshots__/annotation_test.ts.snap
@@ -1,5 +1,9 @@
 export const snapshot = {};
 
+snapshot[`isOptionalOf<T> > returns properly named function 1`] = `"isOptionalOf(isNumber)"`;
+
+snapshot[`isOptionalOf<T> > returns properly named function 2`] = `"isOptionalOf(isNumber)"`;
+
 snapshot[`isUnwrapOptionalOf<T> > returns properly named function 1`] = `"isNumber"`;
 
 snapshot[`isUnwrapOptionalOf<T> > returns properly named function 2`] = `"isNumber"`;
@@ -13,7 +17,3 @@ snapshot[`isReadonlyOf<T> > returns properly named function 2`] = `"isReadonlyOf
 snapshot[`isUnwrapReadonlyOf<T> > returns properly named function 1`] = `"isNumber"`;
 
 snapshot[`isUnwrapReadonlyOf<T> > returns properly named function 2`] = `"isReadonlyOf(isNumber)"`;
-
-snapshot[`isOptionalOf<T> > returns properly named function 1`] = `"isOptionalOf(isNumber)"`;
-
-snapshot[`isOptionalOf<T> > returns properly named function 2`] = `"isOptionalOf(isNumber)"`;

--- a/is/__snapshots__/factory_test.ts.snap
+++ b/is/__snapshots__/factory_test.ts.snap
@@ -1,8 +1,12 @@
 export const snapshot = {};
 
-snapshot[`isInstanceOf<T> > returns properly named function 1`] = `"isInstanceOf(Date)"`;
+snapshot[`isArrayOf<T> > returns properly named function 1`] = `"isArrayOf(isNumber)"`;
 
-snapshot[`isInstanceOf<T> > returns properly named function 2`] = `"isInstanceOf((anonymous))"`;
+snapshot[`isArrayOf<T> > returns properly named function 2`] = `"isArrayOf((anonymous))"`;
+
+snapshot[`isSetOf<T> > returns properly named function 1`] = `"isSetOf(isNumber)"`;
+
+snapshot[`isSetOf<T> > returns properly named function 2`] = `"isSetOf((anonymous))"`;
 
 snapshot[`isTupleOf<T> > returns properly named function 1`] = `
 "isTupleOf([
@@ -26,99 +30,27 @@ snapshot[`isTupleOf<T> > returns properly named function 3`] = `
 ])"
 `;
 
-snapshot[`isRecordLikeOf<T> > returns properly named function 1`] = `"isRecordLikeOf(isNumber, undefined)"`;
-
-snapshot[`isRecordLikeOf<T> > returns properly named function 2`] = `"isRecordLikeOf((anonymous), undefined)"`;
-
-snapshot[`isRecordLikeOf<T, K> > returns properly named function 1`] = `"isRecordLikeOf(isNumber, isString)"`;
-
-snapshot[`isRecordLikeOf<T, K> > returns properly named function 2`] = `"isRecordLikeOf((anonymous), isString)"`;
-
-snapshot[`isMapOf<T, K> > returns properly named function 1`] = `"isMapOf(isNumber, isString)"`;
-
-snapshot[`isMapOf<T, K> > returns properly named function 2`] = `"isMapOf((anonymous), isString)"`;
-
-snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 1`] = `
-"isReadonlyOf(isTupleOf([
+snapshot[`isTupleOf<T, E> > returns properly named function 1`] = `
+"isTupleOf([
   isNumber,
   isString,
   isBoolean
-], isArray))"
+], isArray)"
 `;
 
-snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 2`] = `"isReadonlyOf(isTupleOf([(anonymous)], isArrayOf(isString)))"`;
+snapshot[`isTupleOf<T, E> > returns properly named function 2`] = `"isTupleOf([(anonymous)], isArrayOf(isString))"`;
 
-snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 3`] = `
-"isReadonlyOf(isTupleOf([
-  isReadonlyOf(isTupleOf([
-    isReadonlyOf(isTupleOf([
+snapshot[`isTupleOf<T, E> > returns properly named function 3`] = `
+"isTupleOf([
+  isTupleOf([
+    isTupleOf([
       isNumber,
       isString,
       isBoolean
-    ], isArray))
-  ], isArray))
-], isArray))"
+    ], isArray)
+  ], isArray)
+])"
 `;
-
-snapshot[`isMapOf<T> > returns properly named function 1`] = `"isMapOf(isNumber, undefined)"`;
-
-snapshot[`isMapOf<T> > returns properly named function 2`] = `"isMapOf((anonymous), undefined)"`;
-
-snapshot[`isObjectOf<T> > returns properly named function 1`] = `
-"isObjectOf({
-  a: isNumber,
-  b: isString,
-  c: isBoolean
-})"
-`;
-
-snapshot[`isObjectOf<T> > returns properly named function 2`] = `"isObjectOf({a: a})"`;
-
-snapshot[`isObjectOf<T> > returns properly named function 3`] = `
-"isObjectOf({
-  a: isObjectOf({
-    b: isObjectOf({c: isBoolean})
-  })
-})"
-`;
-
-snapshot[`isRecordOf<T> > returns properly named function 1`] = `"isRecordOf(isNumber, undefined)"`;
-
-snapshot[`isRecordOf<T> > returns properly named function 2`] = `"isRecordOf((anonymous), undefined)"`;
-
-snapshot[`isStrictOf<T> > returns properly named function 1`] = `
-"isStrictOf(isObjectOf({
-  a: isNumber,
-  b: isString,
-  c: isBoolean
-}))"
-`;
-
-snapshot[`isStrictOf<T> > returns properly named function 2`] = `"isStrictOf(isObjectOf({a: a}))"`;
-
-snapshot[`isStrictOf<T> > returns properly named function 3`] = `
-"isStrictOf(isObjectOf({
-  a: isStrictOf(isObjectOf({
-    b: isStrictOf(isObjectOf({c: isBoolean}))
-  }))
-}))"
-`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 1`] = `'isLiteralOf("hello")'`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 2`] = `"isLiteralOf(100)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 3`] = `"isLiteralOf(100n)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 4`] = `"isLiteralOf(true)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 5`] = `"isLiteralOf(null)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 6`] = `"isLiteralOf(undefined)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 7`] = `"isLiteralOf(Symbol(asdf))"`;
-
-snapshot[`isLiteralOneOf<T> > returns properly named function 1`] = `'isLiteralOneOf(["hello", "world"])'`;
 
 snapshot[`isReadonlyTupleOf<T> > returns properly named function 1`] = `
 "isReadonlyOf(isTupleOf([
@@ -142,11 +74,27 @@ snapshot[`isReadonlyTupleOf<T> > returns properly named function 3`] = `
 ]))"
 `;
 
-snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 1`] = `"isReadonlyOf(isUniformTupleOf(3, isAny))"`;
+snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 1`] = `
+"isReadonlyOf(isTupleOf([
+  isNumber,
+  isString,
+  isBoolean
+], isArray))"
+`;
 
-snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 2`] = `"isReadonlyOf(isUniformTupleOf(3, isNumber))"`;
+snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 2`] = `"isReadonlyOf(isTupleOf([(anonymous)], isArrayOf(isString)))"`;
 
-snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 3`] = `"isReadonlyOf(isUniformTupleOf(3, (anonymous)))"`;
+snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 3`] = `
+"isReadonlyOf(isTupleOf([
+  isReadonlyOf(isTupleOf([
+    isReadonlyOf(isTupleOf([
+      isNumber,
+      isString,
+      isBoolean
+    ], isArray))
+  ], isArray))
+], isArray))"
+`;
 
 snapshot[`isUniformTupleOf<T> > returns properly named function 1`] = `"isUniformTupleOf(3, isAny)"`;
 
@@ -154,36 +102,88 @@ snapshot[`isUniformTupleOf<T> > returns properly named function 2`] = `"isUnifor
 
 snapshot[`isUniformTupleOf<T> > returns properly named function 3`] = `"isUniformTupleOf(3, (anonymous))"`;
 
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 1`] = `"isReadonlyOf(isUniformTupleOf(3, isAny))"`;
+
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 2`] = `"isReadonlyOf(isUniformTupleOf(3, isNumber))"`;
+
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 3`] = `"isReadonlyOf(isUniformTupleOf(3, (anonymous)))"`;
+
+snapshot[`isRecordOf<T> > returns properly named function 1`] = `"isRecordOf(isNumber, undefined)"`;
+
+snapshot[`isRecordOf<T> > returns properly named function 2`] = `"isRecordOf((anonymous), undefined)"`;
+
 snapshot[`isRecordOf<T, K> > returns properly named function 1`] = `"isRecordOf(isNumber, isString)"`;
 
 snapshot[`isRecordOf<T, K> > returns properly named function 2`] = `"isRecordOf((anonymous), isString)"`;
 
-snapshot[`isArrayOf<T> > returns properly named function 1`] = `"isArrayOf(isNumber)"`;
+snapshot[`isRecordLikeOf<T> > returns properly named function 1`] = `"isRecordLikeOf(isNumber, undefined)"`;
 
-snapshot[`isArrayOf<T> > returns properly named function 2`] = `"isArrayOf((anonymous))"`;
+snapshot[`isRecordLikeOf<T> > returns properly named function 2`] = `"isRecordLikeOf((anonymous), undefined)"`;
 
-snapshot[`isTupleOf<T, E> > returns properly named function 1`] = `
-"isTupleOf([
-  isNumber,
-  isString,
-  isBoolean
-], isArray)"
+snapshot[`isRecordLikeOf<T, K> > returns properly named function 1`] = `"isRecordLikeOf(isNumber, isString)"`;
+
+snapshot[`isRecordLikeOf<T, K> > returns properly named function 2`] = `"isRecordLikeOf((anonymous), isString)"`;
+
+snapshot[`isMapOf<T> > returns properly named function 1`] = `"isMapOf(isNumber, undefined)"`;
+
+snapshot[`isMapOf<T> > returns properly named function 2`] = `"isMapOf((anonymous), undefined)"`;
+
+snapshot[`isMapOf<T, K> > returns properly named function 1`] = `"isMapOf(isNumber, isString)"`;
+
+snapshot[`isMapOf<T, K> > returns properly named function 2`] = `"isMapOf((anonymous), isString)"`;
+
+snapshot[`isObjectOf<T> > returns properly named function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  b: isString,
+  c: isBoolean
+})"
 `;
 
-snapshot[`isTupleOf<T, E> > returns properly named function 2`] = `"isTupleOf([(anonymous)], isArrayOf(isString))"`;
+snapshot[`isObjectOf<T> > returns properly named function 2`] = `"isObjectOf({a: a})"`;
 
-snapshot[`isTupleOf<T, E> > returns properly named function 3`] = `
-"isTupleOf([
-  isTupleOf([
-    isTupleOf([
-      isNumber,
-      isString,
-      isBoolean
-    ], isArray)
-  ], isArray)
-])"
+snapshot[`isObjectOf<T> > returns properly named function 3`] = `
+"isObjectOf({
+  a: isObjectOf({
+    b: isObjectOf({c: isBoolean})
+  })
+})"
 `;
 
-snapshot[`isSetOf<T> > returns properly named function 1`] = `"isSetOf(isNumber)"`;
+snapshot[`isStrictOf<T> > returns properly named function 1`] = `
+"isStrictOf(isObjectOf({
+  a: isNumber,
+  b: isString,
+  c: isBoolean
+}))"
+`;
 
-snapshot[`isSetOf<T> > returns properly named function 2`] = `"isSetOf((anonymous))"`;
+snapshot[`isStrictOf<T> > returns properly named function 2`] = `"isStrictOf(isObjectOf({a: a}))"`;
+
+snapshot[`isStrictOf<T> > returns properly named function 3`] = `
+"isStrictOf(isObjectOf({
+  a: isStrictOf(isObjectOf({
+    b: isStrictOf(isObjectOf({c: isBoolean}))
+  }))
+}))"
+`;
+
+snapshot[`isInstanceOf<T> > returns properly named function 1`] = `"isInstanceOf(Date)"`;
+
+snapshot[`isInstanceOf<T> > returns properly named function 2`] = `"isInstanceOf((anonymous))"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 1`] = `'isLiteralOf("hello")'`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 2`] = `"isLiteralOf(100)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 3`] = `"isLiteralOf(100n)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 4`] = `"isLiteralOf(true)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 5`] = `"isLiteralOf(null)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 6`] = `"isLiteralOf(undefined)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 7`] = `"isLiteralOf(Symbol(asdf))"`;
+
+snapshot[`isLiteralOneOf<T> > returns properly named function 1`] = `'isLiteralOneOf(["hello", "world"])'`;

--- a/is/__snapshots__/factory_test.ts.snap
+++ b/is/__snapshots__/factory_test.ts.snap
@@ -1,52 +1,8 @@
 export const snapshot = {};
 
-snapshot[`isObjectOf<T> > returns properly named function 1`] = `
-"isObjectOf({
-  a: isNumber,
-  b: isString,
-  c: isBoolean
-})"
-`;
+snapshot[`isInstanceOf<T> > returns properly named function 1`] = `"isInstanceOf(Date)"`;
 
-snapshot[`isObjectOf<T> > returns properly named function 2`] = `"isObjectOf({a: a})"`;
-
-snapshot[`isObjectOf<T> > returns properly named function 3`] = `
-"isObjectOf({
-  a: isObjectOf({
-    b: isObjectOf({c: isBoolean})
-  })
-})"
-`;
-
-snapshot[`isArrayOf<T> > returns properly named function 1`] = `"isArrayOf(isNumber)"`;
-
-snapshot[`isArrayOf<T> > returns properly named function 2`] = `"isArrayOf((anonymous))"`;
-
-snapshot[`isReadonlyTupleOf<T> > returns properly named function 1`] = `
-"isReadonlyOf(isTupleOf([
-  isNumber,
-  isString,
-  isBoolean
-]))"
-`;
-
-snapshot[`isReadonlyTupleOf<T> > returns properly named function 2`] = `"isReadonlyOf(isTupleOf([(anonymous)]))"`;
-
-snapshot[`isReadonlyTupleOf<T> > returns properly named function 3`] = `
-"isReadonlyOf(isTupleOf([
-  isReadonlyOf(isTupleOf([
-    isReadonlyOf(isTupleOf([
-      isNumber,
-      isString,
-      isBoolean
-    ]))
-  ]))
-]))"
-`;
-
-snapshot[`isSetOf<T> > returns properly named function 1`] = `"isSetOf(isNumber)"`;
-
-snapshot[`isSetOf<T> > returns properly named function 2`] = `"isSetOf((anonymous))"`;
+snapshot[`isInstanceOf<T> > returns properly named function 2`] = `"isInstanceOf((anonymous))"`;
 
 snapshot[`isTupleOf<T> > returns properly named function 1`] = `
 "isTupleOf([
@@ -70,9 +26,17 @@ snapshot[`isTupleOf<T> > returns properly named function 3`] = `
 ])"
 `;
 
-snapshot[`isRecordOf<T> > returns properly named function 1`] = `"isRecordOf(isNumber, undefined)"`;
+snapshot[`isRecordLikeOf<T> > returns properly named function 1`] = `"isRecordLikeOf(isNumber, undefined)"`;
 
-snapshot[`isRecordOf<T> > returns properly named function 2`] = `"isRecordOf((anonymous), undefined)"`;
+snapshot[`isRecordLikeOf<T> > returns properly named function 2`] = `"isRecordLikeOf((anonymous), undefined)"`;
+
+snapshot[`isRecordLikeOf<T, K> > returns properly named function 1`] = `"isRecordLikeOf(isNumber, isString)"`;
+
+snapshot[`isRecordLikeOf<T, K> > returns properly named function 2`] = `"isRecordLikeOf((anonymous), isString)"`;
+
+snapshot[`isMapOf<T, K> > returns properly named function 1`] = `"isMapOf(isNumber, isString)"`;
+
+snapshot[`isMapOf<T, K> > returns properly named function 2`] = `"isMapOf((anonymous), isString)"`;
 
 snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 1`] = `
 "isReadonlyOf(isTupleOf([
@@ -96,6 +60,108 @@ snapshot[`isReadonlyTupleOf<T, E> > returns properly named function 3`] = `
 ], isArray))"
 `;
 
+snapshot[`isMapOf<T> > returns properly named function 1`] = `"isMapOf(isNumber, undefined)"`;
+
+snapshot[`isMapOf<T> > returns properly named function 2`] = `"isMapOf((anonymous), undefined)"`;
+
+snapshot[`isObjectOf<T> > returns properly named function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  b: isString,
+  c: isBoolean
+})"
+`;
+
+snapshot[`isObjectOf<T> > returns properly named function 2`] = `"isObjectOf({a: a})"`;
+
+snapshot[`isObjectOf<T> > returns properly named function 3`] = `
+"isObjectOf({
+  a: isObjectOf({
+    b: isObjectOf({c: isBoolean})
+  })
+})"
+`;
+
+snapshot[`isRecordOf<T> > returns properly named function 1`] = `"isRecordOf(isNumber, undefined)"`;
+
+snapshot[`isRecordOf<T> > returns properly named function 2`] = `"isRecordOf((anonymous), undefined)"`;
+
+snapshot[`isStrictOf<T> > returns properly named function 1`] = `
+"isStrictOf(isObjectOf({
+  a: isNumber,
+  b: isString,
+  c: isBoolean
+}))"
+`;
+
+snapshot[`isStrictOf<T> > returns properly named function 2`] = `"isStrictOf(isObjectOf({a: a}))"`;
+
+snapshot[`isStrictOf<T> > returns properly named function 3`] = `
+"isStrictOf(isObjectOf({
+  a: isStrictOf(isObjectOf({
+    b: isStrictOf(isObjectOf({c: isBoolean}))
+  }))
+}))"
+`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 1`] = `'isLiteralOf("hello")'`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 2`] = `"isLiteralOf(100)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 3`] = `"isLiteralOf(100n)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 4`] = `"isLiteralOf(true)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 5`] = `"isLiteralOf(null)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 6`] = `"isLiteralOf(undefined)"`;
+
+snapshot[`isLiteralOf<T> > returns properly named function 7`] = `"isLiteralOf(Symbol(asdf))"`;
+
+snapshot[`isLiteralOneOf<T> > returns properly named function 1`] = `'isLiteralOneOf(["hello", "world"])'`;
+
+snapshot[`isReadonlyTupleOf<T> > returns properly named function 1`] = `
+"isReadonlyOf(isTupleOf([
+  isNumber,
+  isString,
+  isBoolean
+]))"
+`;
+
+snapshot[`isReadonlyTupleOf<T> > returns properly named function 2`] = `"isReadonlyOf(isTupleOf([(anonymous)]))"`;
+
+snapshot[`isReadonlyTupleOf<T> > returns properly named function 3`] = `
+"isReadonlyOf(isTupleOf([
+  isReadonlyOf(isTupleOf([
+    isReadonlyOf(isTupleOf([
+      isNumber,
+      isString,
+      isBoolean
+    ]))
+  ]))
+]))"
+`;
+
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 1`] = `"isReadonlyOf(isUniformTupleOf(3, isAny))"`;
+
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 2`] = `"isReadonlyOf(isUniformTupleOf(3, isNumber))"`;
+
+snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 3`] = `"isReadonlyOf(isUniformTupleOf(3, (anonymous)))"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 1`] = `"isUniformTupleOf(3, isAny)"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 2`] = `"isUniformTupleOf(3, isNumber)"`;
+
+snapshot[`isUniformTupleOf<T> > returns properly named function 3`] = `"isUniformTupleOf(3, (anonymous))"`;
+
+snapshot[`isRecordOf<T, K> > returns properly named function 1`] = `"isRecordOf(isNumber, isString)"`;
+
+snapshot[`isRecordOf<T, K> > returns properly named function 2`] = `"isRecordOf((anonymous), isString)"`;
+
+snapshot[`isArrayOf<T> > returns properly named function 1`] = `"isArrayOf(isNumber)"`;
+
+snapshot[`isArrayOf<T> > returns properly named function 2`] = `"isArrayOf((anonymous))"`;
+
 snapshot[`isTupleOf<T, E> > returns properly named function 1`] = `
 "isTupleOf([
   isNumber,
@@ -118,64 +184,6 @@ snapshot[`isTupleOf<T, E> > returns properly named function 3`] = `
 ])"
 `;
 
-snapshot[`isInstanceOf<T> > returns properly named function 1`] = `"isInstanceOf(Date)"`;
+snapshot[`isSetOf<T> > returns properly named function 1`] = `"isSetOf(isNumber)"`;
 
-snapshot[`isInstanceOf<T> > returns properly named function 2`] = `"isInstanceOf((anonymous))"`;
-
-snapshot[`isLiteralOneOf<T> > returns properly named function 1`] = `'isLiteralOneOf(["hello", "world"])'`;
-
-snapshot[`isMapOf<T> > returns properly named function 1`] = `"isMapOf(isNumber, undefined)"`;
-
-snapshot[`isMapOf<T> > returns properly named function 2`] = `"isMapOf((anonymous), undefined)"`;
-
-snapshot[`isStrictOf<T> > returns properly named function 1`] = `
-"isStrictOf(isObjectOf({
-  a: isNumber,
-  b: isString,
-  c: isBoolean
-}))"
-`;
-
-snapshot[`isStrictOf<T> > returns properly named function 2`] = `"isStrictOf(isObjectOf({a: a}))"`;
-
-snapshot[`isStrictOf<T> > returns properly named function 3`] = `
-"isStrictOf(isObjectOf({
-  a: isStrictOf(isObjectOf({
-    b: isStrictOf(isObjectOf({c: isBoolean}))
-  }))
-}))"
-`;
-
-snapshot[`isRecordOf<T, K> > returns properly named function 1`] = `"isRecordOf(isNumber, isString)"`;
-
-snapshot[`isRecordOf<T, K> > returns properly named function 2`] = `"isRecordOf((anonymous), isString)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 1`] = `'isLiteralOf("hello")'`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 2`] = `"isLiteralOf(100)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 3`] = `"isLiteralOf(100n)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 4`] = `"isLiteralOf(true)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 5`] = `"isLiteralOf(null)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 6`] = `"isLiteralOf(undefined)"`;
-
-snapshot[`isLiteralOf<T> > returns properly named function 7`] = `"isLiteralOf(Symbol(asdf))"`;
-
-snapshot[`isMapOf<T, K> > returns properly named function 1`] = `"isMapOf(isNumber, isString)"`;
-
-snapshot[`isMapOf<T, K> > returns properly named function 2`] = `"isMapOf((anonymous), isString)"`;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 1`] = `"isUniformTupleOf(3, isAny)"`;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 2`] = `"isUniformTupleOf(3, isNumber)"`;
-
-snapshot[`isUniformTupleOf<T> > returns properly named function 3`] = `"isUniformTupleOf(3, (anonymous))"`;
-
-snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 1`] = `"isReadonlyOf(isUniformTupleOf(3, isAny))"`;
-
-snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 2`] = `"isReadonlyOf(isUniformTupleOf(3, isNumber))"`;
-
-snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 3`] = `"isReadonlyOf(isUniformTupleOf(3, (anonymous)))"`;
+snapshot[`isSetOf<T> > returns properly named function 2`] = `"isSetOf((anonymous))"`;

--- a/is/__snapshots__/utility_test.ts.snap
+++ b/is/__snapshots__/utility_test.ts.snap
@@ -1,22 +1,5 @@
 export const snapshot = {};
 
-snapshot[`isUnionOf<T> > returns properly named function 1`] = `
-"isUnionOf([
-  isNumber,
-  isString,
-  isBoolean
-])"
-`;
-
-snapshot[`isOmitOf<T, K> > returns properly named function 1`] = `
-"isObjectOf({
-  a: isNumber,
-  c: isBoolean
-})"
-`;
-
-snapshot[`isOmitOf<T, K> > returns properly named function 2`] = `"isObjectOf({a: isNumber})"`;
-
 snapshot[`isPartialOf<T> > returns properly named function 1`] = `
 "isObjectOf({
   a: isOptionalOf(isNumber),
@@ -38,15 +21,6 @@ snapshot[`isPartialOf<T> > returns properly named function 2`] = `
   c: isOptionalOf(isBoolean)
 })"
 `;
-
-snapshot[`isPickOf<T, K> > returns properly named function 1`] = `
-"isObjectOf({
-  a: isNumber,
-  c: isBoolean
-})"
-`;
-
-snapshot[`isPickOf<T, K> > returns properly named function 2`] = `"isObjectOf({a: isNumber})"`;
 
 snapshot[`isRequiredOf<T> > returns properly named function 1`] = `
 "isObjectOf({
@@ -75,4 +49,30 @@ snapshot[`isIntersectionOf<T> > returns properly named function 1`] = `
   a: isNumber,
   b: isString
 })"
+`;
+
+snapshot[`isPickOf<T, K> > returns properly named function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  c: isBoolean
+})"
+`;
+
+snapshot[`isPickOf<T, K> > returns properly named function 2`] = `"isObjectOf({a: isNumber})"`;
+
+snapshot[`isOmitOf<T, K> > returns properly named function 1`] = `
+"isObjectOf({
+  a: isNumber,
+  c: isBoolean
+})"
+`;
+
+snapshot[`isOmitOf<T, K> > returns properly named function 2`] = `"isObjectOf({a: isNumber})"`;
+
+snapshot[`isUnionOf<T> > returns properly named function 1`] = `
+"isUnionOf([
+  isNumber,
+  isString,
+  isBoolean
+])"
 `;

--- a/is/__snapshots__/utility_test.ts.snap
+++ b/is/__snapshots__/utility_test.ts.snap
@@ -1,24 +1,17 @@
 export const snapshot = {};
 
-snapshot[`isPartialOf<T> > returns properly named function 1`] = `
-"isObjectOf({
-  a: isOptionalOf(isNumber),
-  b: isOptionalOf(isUnionOf([
-    isString,
-    isUndefined
-  ])),
-  c: isOptionalOf(isBoolean)
-})"
+snapshot[`isUnionOf<T> > returns properly named function 1`] = `
+"isUnionOf([
+  isNumber,
+  isString,
+  isBoolean
+])"
 `;
 
-snapshot[`isPartialOf<T> > returns properly named function 2`] = `
+snapshot[`isIntersectionOf<T> > returns properly named function 1`] = `
 "isObjectOf({
-  a: isOptionalOf(isNumber),
-  b: isOptionalOf(isUnionOf([
-    isString,
-    isUndefined
-  ])),
-  c: isOptionalOf(isBoolean)
+  a: isNumber,
+  b: isString
 })"
 `;
 
@@ -44,10 +37,25 @@ snapshot[`isRequiredOf<T> > returns properly named function 2`] = `
 })"
 `;
 
-snapshot[`isIntersectionOf<T> > returns properly named function 1`] = `
+snapshot[`isPartialOf<T> > returns properly named function 1`] = `
 "isObjectOf({
-  a: isNumber,
-  b: isString
+  a: isOptionalOf(isNumber),
+  b: isOptionalOf(isUnionOf([
+    isString,
+    isUndefined
+  ])),
+  c: isOptionalOf(isBoolean)
+})"
+`;
+
+snapshot[`isPartialOf<T> > returns properly named function 2`] = `
+"isObjectOf({
+  a: isOptionalOf(isNumber),
+  b: isOptionalOf(isUnionOf([
+    isString,
+    isUndefined
+  ])),
+  c: isOptionalOf(isBoolean)
 })"
 `;
 
@@ -68,11 +76,3 @@ snapshot[`isOmitOf<T, K> > returns properly named function 1`] = `
 `;
 
 snapshot[`isOmitOf<T, K> > returns properly named function 2`] = `"isObjectOf({a: isNumber})"`;
-
-snapshot[`isUnionOf<T> > returns properly named function 1`] = `
-"isUnionOf([
-  isNumber,
-  isString,
-  isBoolean
-])"
-`;

--- a/is/core.ts
+++ b/is/core.ts
@@ -142,6 +142,9 @@ export function isSet(x: unknown): x is Set<unknown> {
 /**
  * Return `true` if the type of `x` is `Record<PropertyKey, unknown>`.
  *
+ * Note that this function check if the `x` is an instance of `Object`.
+ * Use `isRecordLike` instead if you want to check if the `x` satisfies the `Record<PropertyKey, unknown>` type.
+ *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
@@ -156,6 +159,33 @@ export function isRecord(
   x: unknown,
 ): x is Record<PropertyKey, unknown> {
   return x != null && typeof x === "object" && x.constructor === Object;
+}
+
+/**
+ * Return `true` if the type of `x` is like `Record<PropertyKey, unknown>`.
+ *
+ * Note that this function returns `true` for ambiguous instances like `Set`, `Map`, `Date`, `Promise`, etc.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = {"a": 0, "b": 1};
+ * if (is.RecordLike(a)) {
+ *   // a is narrowed to Record<PropertyKey, unknown>
+ *   const _: Record<PropertyKey, unknown> = a;
+ * }
+ *
+ * const b: unknown = new Date();
+ * if (is.RecordLike(b)) {
+ *   // a is narrowed to Record<PropertyKey, unknown>
+ *   const _: Record<PropertyKey, unknown> = b;
+ * }
+ * ```
+ */
+export function isRecordLike(
+  x: unknown,
+): x is Record<PropertyKey, unknown> {
+  return x != null && !Array.isArray(x) && typeof x === "object";
 }
 
 /**
@@ -345,6 +375,7 @@ export default {
   Number: isNumber,
   Primitive: isPrimitive,
   Record: isRecord,
+  RecordLike: isRecordLike,
   Set: isSet,
   String: isString,
   Symbol: isSymbol,

--- a/is/core_test.ts
+++ b/is/core_test.ts
@@ -17,6 +17,7 @@ import is, {
   isNumber,
   isPrimitive,
   isRecord,
+  isRecordLike,
   isSet,
   isString,
   isSymbol,
@@ -144,6 +145,12 @@ Deno.test("isSet", async (t) => {
 Deno.test("isRecord", async (t) => {
   await testWithExamples(t, isRecord, {
     validExamples: ["record"],
+  });
+});
+
+Deno.test("isRecordLike", async (t) => {
+  await testWithExamples(t, isRecordLike, {
+    validExamples: ["record", "date", "promise", "set", "map"],
   });
 });
 

--- a/is/factory.ts
+++ b/is/factory.ts
@@ -6,6 +6,7 @@ import {
   isArray,
   isMap,
   isRecord,
+  isRecordLike,
   isSet,
   type Primitive,
 } from "./core.ts";
@@ -371,6 +372,9 @@ export function isReadonlyUniformTupleOf<T, N extends number>(
  *
  * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
  *
+ * Note that this function check if the `x` is an instance of `Object`.
+ * Use `isRecordLikeOf` instead if you want to check if the `x` satisfies the `Record<K, T>` type.
+ *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
  *
@@ -415,6 +419,57 @@ export function isRecordOf<T, K extends PropertyKey = PropertyKey>(
 type IsRecordOfMetadata = {
   name: "isRecordOf";
   args: Parameters<typeof isRecordOf>;
+};
+
+/**
+ * Return a type predicate function that returns `true` if the type of `x` is like `Record<K, T>`.
+ *
+ * To enhance performance, users are advised to cache the return value of this function and mitigate the creation cost.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const isMyType = is.RecordLikeOf(is.Number);
+ * const a: unknown = {"a": 0, "b": 1};
+ * if (isMyType(a)) {
+ *   // a is narrowed to Record<PropertyKey, number>
+ *   const _: Record<PropertyKey, number> = a;
+ * }
+ * ```
+ *
+ * With predicate function for keys:
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const isMyType = is.RecordOf(is.Number, is.String);
+ * const a: unknown = {"a": 0, "b": 1};
+ * if (isMyType(a)) {
+ *   // a is narrowed to Record<string, number>
+ *   const _: Record<string, number> = a;
+ * }
+ * ```
+ */
+export function isRecordLikeOf<T, K extends PropertyKey = PropertyKey>(
+  pred: Predicate<T>,
+  predKey?: Predicate<K>,
+): Predicate<Record<K, T>> & WithMetadata<IsRecordLikeOfMetadata> {
+  return setPredicateFactoryMetadata(
+    (x: unknown): x is Record<K, T> => {
+      if (!isRecordLike(x)) return false;
+      for (const k in x) {
+        if (!pred(x[k])) return false;
+        if (predKey && !predKey(k)) return false;
+      }
+      return true;
+    },
+    { name: "isRecordLikeOf", args: [pred, predKey] },
+  );
+}
+
+type IsRecordLikeOfMetadata = {
+  name: "isRecordLikeOf";
+  args: Parameters<typeof isRecordLikeOf>;
 };
 
 /**
@@ -691,6 +746,7 @@ export default {
   ObjectOf: isObjectOf,
   ReadonlyTupleOf: isReadonlyTupleOf,
   ReadonlyUniformTupleOf: isReadonlyUniformTupleOf,
+  RecordLikeOf: isRecordLikeOf,
   RecordOf: isRecordOf,
   SetOf: isSetOf,
   StrictOf: isStrictOf,

--- a/is/factory.ts
+++ b/is/factory.ts
@@ -563,7 +563,7 @@ export function isObjectOf<
   }
   return setPredicateFactoryMetadata(
     (x: unknown): x is ObjectOf<T> => {
-      if (x == null || typeof x !== "object") return false;
+      if (x == null || typeof x !== "object" || Array.isArray(x)) return false;
       // Check each values
       for (const k in predObj) {
         if (!predObj[k]((x as T)[k])) return false;

--- a/is/factory_test.ts
+++ b/is/factory_test.ts
@@ -26,6 +26,7 @@ import is, {
   isObjectOf,
   isReadonlyTupleOf,
   isReadonlyUniformTupleOf,
+  isRecordLikeOf,
   isRecordOf,
   isSetOf,
   isStrictOf,
@@ -448,7 +449,7 @@ Deno.test("isRecordOf<T>", async (t) => {
     assertEquals(isRecordOf(isString)({ a: true }), false);
   });
   await testWithExamples(t, isRecordOf((_: unknown): _ is unknown => true), {
-    excludeExamples: ["record", "date", "promise"],
+    excludeExamples: ["record"],
   });
 });
 
@@ -482,8 +483,76 @@ Deno.test("isRecordOf<T, K>", async (t) => {
     assertEquals(isRecordOf(isBoolean, isNumber)({ a: true }), false);
   });
   await testWithExamples(t, isRecordOf((_: unknown): _ is unknown => true), {
-    excludeExamples: ["record", "date", "promise"],
+    excludeExamples: ["record"],
   });
+});
+
+Deno.test("isRecordLikeOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isRecordLikeOf(isNumber).name);
+    await assertSnapshot(t, isRecordLikeOf((_x): _x is string => false).name);
+  });
+  await t.step("returns proper type predicate", () => {
+    const a: unknown = { a: 0 };
+    if (isRecordLikeOf(isNumber)(a)) {
+      assertType<Equal<typeof a, Record<PropertyKey, number>>>(true);
+    }
+  });
+  await t.step("returns true on T record", () => {
+    assertEquals(isRecordLikeOf(isNumber)({ a: 0 }), true);
+    assertEquals(isRecordLikeOf(isString)({ a: "a" }), true);
+    assertEquals(isRecordLikeOf(isBoolean)({ a: true }), true);
+  });
+  await t.step("returns false on non T record", () => {
+    assertEquals(isRecordLikeOf(isString)({ a: 0 }), false);
+    assertEquals(isRecordLikeOf(isNumber)({ a: "a" }), false);
+    assertEquals(isRecordLikeOf(isString)({ a: true }), false);
+  });
+  await testWithExamples(
+    t,
+    isRecordLikeOf((_: unknown): _ is unknown => true),
+    {
+      excludeExamples: ["record", "date", "promise", "set", "map"],
+    },
+  );
+});
+
+Deno.test("isRecordLikeOf<T, K>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isRecordLikeOf(isNumber, isString).name);
+    await assertSnapshot(
+      t,
+      isRecordLikeOf((_x): _x is string => false, isString).name,
+    );
+  });
+  await t.step("returns proper type predicate", () => {
+    const a: unknown = { a: 0 };
+    if (isRecordLikeOf(isNumber, isString)(a)) {
+      assertType<Equal<typeof a, Record<string, number>>>(true);
+    }
+  });
+  await t.step("returns true on T record", () => {
+    assertEquals(isRecordLikeOf(isNumber, isString)({ a: 0 }), true);
+    assertEquals(isRecordLikeOf(isString, isString)({ a: "a" }), true);
+    assertEquals(isRecordLikeOf(isBoolean, isString)({ a: true }), true);
+  });
+  await t.step("returns false on non T record", () => {
+    assertEquals(isRecordLikeOf(isString, isString)({ a: 0 }), false);
+    assertEquals(isRecordLikeOf(isNumber, isString)({ a: "a" }), false);
+    assertEquals(isRecordLikeOf(isString, isString)({ a: true }), false);
+  });
+  await t.step("returns false on non K record", () => {
+    assertEquals(isRecordLikeOf(isNumber, isNumber)({ a: 0 }), false);
+    assertEquals(isRecordLikeOf(isString, isNumber)({ a: "a" }), false);
+    assertEquals(isRecordLikeOf(isBoolean, isNumber)({ a: true }), false);
+  });
+  await testWithExamples(
+    t,
+    isRecordLikeOf((_: unknown): _ is unknown => true),
+    {
+      excludeExamples: ["record", "date", "promise", "set", "map"],
+    },
+  );
 });
 
 Deno.test("isMapOf<T>", async (t) => {

--- a/is/factory_test.ts
+++ b/is/factory_test.ts
@@ -687,6 +687,11 @@ Deno.test("isObjectOf<T>", async (t) => {
       false,
       "Specify `{ strict: true }` and object have an unknown property",
     );
+    assertEquals(
+      isObjectOf({ 0: isString })(["a"]),
+      false,
+      "Value is not an object",
+    );
   });
   await t.step("returns true on T instance", () => {
     const date = new Date();


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new validation function `isRecordLike` to check for record-like objects.
	- Added `isRecordLikeOf` function for more specific record-like object checks, including type parameters.
- **Bug Fixes**
	- Modified test execution order by removing the `--shuffle` flag for more predictable outcomes.
	- Refined the `isRecord` function to improve clarity and direct users towards `isRecordLike` for certain checks.
	- Adjusted `isObjectOf` to correctly exclude arrays from being considered objects.
- **Documentation**
	- Updated documentation to reflect the introduction of `isRecordLike` and `isRecordLikeOf` functions and their intended use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->