### PR TITLE
:boom: Rename `isRecord/isRecordOf/isRecordLike/isRecordLikeOf`

### DIFF
--- a/is/__snapshots__/factory_test.ts.snap
+++ b/is/__snapshots__/factory_test.ts.snap
@@ -108,6 +108,14 @@ snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 2`] = `"
 
 snapshot[`isReadonlyUniformTupleOf<T> > returns properly named function 3`] = `"isReadonlyOf(isUniformTupleOf(3, (anonymous)))"`;
 
+snapshot[`isRecordObjectOf<T> > returns properly named function 1`] = `"isRecordObjectOf(isNumber, undefined)"`;
+
+snapshot[`isRecordObjectOf<T> > returns properly named function 2`] = `"isRecordObjectOf((anonymous), undefined)"`;
+
+snapshot[`isRecordObjectOf<T, K> > returns properly named function 1`] = `"isRecordObjectOf(isNumber, isString)"`;
+
+snapshot[`isRecordObjectOf<T, K> > returns properly named function 2`] = `"isRecordObjectOf((anonymous), isString)"`;
+
 snapshot[`isRecordOf<T> > returns properly named function 1`] = `"isRecordOf(isNumber, undefined)"`;
 
 snapshot[`isRecordOf<T> > returns properly named function 2`] = `"isRecordOf((anonymous), undefined)"`;

--- a/is/annotation_test.ts
+++ b/is/annotation_test.ts
@@ -16,7 +16,7 @@ import {
   isFunction,
   isNull,
   isNumber,
-  isRecord,
+  isRecordObject,
   isSet,
   isString,
   isSymbol,
@@ -121,8 +121,8 @@ Deno.test("isOptionalOf<T>", async (t) => {
       validExamples: ["set", "undefined"],
     });
   });
-  await t.step("with isRecord", async (t) => {
-    await testWithExamples(t, isOptionalOf(isRecord), {
+  await t.step("with isRecordObject", async (t) => {
+    await testWithExamples(t, isOptionalOf(isRecordObject), {
       validExamples: ["record", "undefined"],
     });
   });
@@ -208,10 +208,14 @@ Deno.test("isUnwrapOptionalOf<T>", async (t) => {
       validExamples: ["set"],
     });
   });
-  await t.step("with isRecord", async (t) => {
-    await testWithExamples(t, isUnwrapOptionalOf(isOptionalOf(isRecord)), {
-      validExamples: ["record"],
-    });
+  await t.step("with isRecordObject", async (t) => {
+    await testWithExamples(
+      t,
+      isUnwrapOptionalOf(isOptionalOf(isRecordObject)),
+      {
+        validExamples: ["record"],
+      },
+    );
   });
   await t.step("with isFunction", async (t) => {
     await testWithExamples(t, isUnwrapOptionalOf(isOptionalOf(isFunction)), {

--- a/is/core.ts
+++ b/is/core.ts
@@ -140,10 +140,36 @@ export function isSet(x: unknown): x is Set<unknown> {
 }
 
 /**
- * Return `true` if the type of `x` is `Record<PropertyKey, unknown>`.
+ * Return `true` if the type of `x` is an object instance that satisfies `Record<PropertyKey, unknown>`.
  *
  * Note that this function check if the `x` is an instance of `Object`.
  * Use `isRecordLike` instead if you want to check if the `x` satisfies the `Record<PropertyKey, unknown>` type.
+ *
+ * ```ts
+ * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
+ *
+ * const a: unknown = {"a": 0, "b": 1};
+ * if (is.RecordObject(a)) {
+ *   // a is narrowed to Record<PropertyKey, unknown>
+ *   const _: Record<PropertyKey, unknown> = a;
+ * }
+ *
+ * const b: unknown = new Set();
+ * if (is.RecordObject(b)) {
+ *   // b is not a raw object, so it is not narrowed
+ * }
+ * ```
+ */
+export function isRecordObject(
+  x: unknown,
+): x is Record<PropertyKey, unknown> {
+  return x != null && typeof x === "object" && x.constructor === Object;
+}
+
+/**
+ * Return `true` if the type of `x` satisfies `Record<PropertyKey, unknown>`.
+ *
+ * Note that this function returns `true` for ambiguous instances like `Set`, `Map`, `Date`, `Promise`, etc.
  *
  * ```ts
  * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
@@ -153,33 +179,24 @@ export function isSet(x: unknown): x is Set<unknown> {
  *   // a is narrowed to Record<PropertyKey, unknown>
  *   const _: Record<PropertyKey, unknown> = a;
  * }
+ *
+ * const b: unknown = new Set();
+ * if (is.Record(b)) {
+ *   // b is narrowed to Record<PropertyKey, unknown>
+ *   const _: Record<PropertyKey, unknown> = b;
+ * }
  * ```
  */
 export function isRecord(
   x: unknown,
 ): x is Record<PropertyKey, unknown> {
-  return x != null && typeof x === "object" && x.constructor === Object;
+  return x != null && !Array.isArray(x) && typeof x === "object";
 }
 
 /**
  * Return `true` if the type of `x` is like `Record<PropertyKey, unknown>`.
  *
- * Note that this function returns `true` for ambiguous instances like `Set`, `Map`, `Date`, `Promise`, etc.
- *
- * ```ts
- * import { is } from "https://deno.land/x/unknownutil@$MODULE_VERSION/mod.ts";
- *
- * const a: unknown = {"a": 0, "b": 1};
- * if (is.RecordLike(a)) {
- *   // a is narrowed to Record<PropertyKey, unknown>
- *   const _: Record<PropertyKey, unknown> = a;
- * }
- *
- * const b: unknown = new Date();
- * if (is.RecordLike(b)) {
- *   // a is narrowed to Record<PropertyKey, unknown>
- *   const _: Record<PropertyKey, unknown> = b;
- * }
+ * @deprecated Use `is.Record` instead.
  * ```
  */
 export function isRecordLike(
@@ -376,6 +393,7 @@ export default {
   Primitive: isPrimitive,
   Record: isRecord,
   RecordLike: isRecordLike,
+  RecordObject: isRecordObject,
   Set: isSet,
   String: isString,
   Symbol: isSymbol,

--- a/is/core_test.ts
+++ b/is/core_test.ts
@@ -18,6 +18,7 @@ import is, {
   isPrimitive,
   isRecord,
   isRecordLike,
+  isRecordObject,
   isSet,
   isString,
   isSymbol,
@@ -142,9 +143,15 @@ Deno.test("isSet", async (t) => {
   await testWithExamples(t, isSet, { validExamples: ["set"] });
 });
 
+Deno.test("isRecordObject", async (t) => {
+  await testWithExamples(t, isRecordObject, {
+    validExamples: ["record"],
+  });
+});
+
 Deno.test("isRecord", async (t) => {
   await testWithExamples(t, isRecord, {
-    validExamples: ["record"],
+    validExamples: ["record", "date", "promise", "set", "map"],
   });
 });
 

--- a/is/factory_test.ts
+++ b/is/factory_test.ts
@@ -27,6 +27,7 @@ import is, {
   isReadonlyTupleOf,
   isReadonlyUniformTupleOf,
   isRecordLikeOf,
+  isRecordObjectOf,
   isRecordOf,
   isSetOf,
   isStrictOf,
@@ -427,6 +428,74 @@ Deno.test("isReadonlyUniformTupleOf<T>", async (t) => {
   });
 });
 
+Deno.test("isRecordObjectOf<T>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isRecordObjectOf(isNumber).name);
+    await assertSnapshot(t, isRecordObjectOf((_x): _x is string => false).name);
+  });
+  await t.step("returns proper type predicate", () => {
+    const a: unknown = { a: 0 };
+    if (isRecordObjectOf(isNumber)(a)) {
+      assertType<Equal<typeof a, Record<PropertyKey, number>>>(true);
+    }
+  });
+  await t.step("returns true on T record", () => {
+    assertEquals(isRecordObjectOf(isNumber)({ a: 0 }), true);
+    assertEquals(isRecordObjectOf(isString)({ a: "a" }), true);
+    assertEquals(isRecordObjectOf(isBoolean)({ a: true }), true);
+  });
+  await t.step("returns false on non T record", () => {
+    assertEquals(isRecordObjectOf(isString)({ a: 0 }), false);
+    assertEquals(isRecordObjectOf(isNumber)({ a: "a" }), false);
+    assertEquals(isRecordObjectOf(isString)({ a: true }), false);
+  });
+  await testWithExamples(
+    t,
+    isRecordObjectOf((_: unknown): _ is unknown => true),
+    {
+      excludeExamples: ["record"],
+    },
+  );
+});
+
+Deno.test("isRecordObjectOf<T, K>", async (t) => {
+  await t.step("returns properly named function", async (t) => {
+    await assertSnapshot(t, isRecordObjectOf(isNumber, isString).name);
+    await assertSnapshot(
+      t,
+      isRecordObjectOf((_x): _x is string => false, isString).name,
+    );
+  });
+  await t.step("returns proper type predicate", () => {
+    const a: unknown = { a: 0 };
+    if (isRecordObjectOf(isNumber, isString)(a)) {
+      assertType<Equal<typeof a, Record<string, number>>>(true);
+    }
+  });
+  await t.step("returns true on T record", () => {
+    assertEquals(isRecordObjectOf(isNumber, isString)({ a: 0 }), true);
+    assertEquals(isRecordObjectOf(isString, isString)({ a: "a" }), true);
+    assertEquals(isRecordObjectOf(isBoolean, isString)({ a: true }), true);
+  });
+  await t.step("returns false on non T record", () => {
+    assertEquals(isRecordObjectOf(isString, isString)({ a: 0 }), false);
+    assertEquals(isRecordObjectOf(isNumber, isString)({ a: "a" }), false);
+    assertEquals(isRecordObjectOf(isString, isString)({ a: true }), false);
+  });
+  await t.step("returns false on non K record", () => {
+    assertEquals(isRecordObjectOf(isNumber, isNumber)({ a: 0 }), false);
+    assertEquals(isRecordObjectOf(isString, isNumber)({ a: "a" }), false);
+    assertEquals(isRecordObjectOf(isBoolean, isNumber)({ a: true }), false);
+  });
+  await testWithExamples(
+    t,
+    isRecordObjectOf((_: unknown): _ is unknown => true),
+    {
+      excludeExamples: ["record"],
+    },
+  );
+});
+
 Deno.test("isRecordOf<T>", async (t) => {
   await t.step("returns properly named function", async (t) => {
     await assertSnapshot(t, isRecordOf(isNumber).name);
@@ -448,9 +517,13 @@ Deno.test("isRecordOf<T>", async (t) => {
     assertEquals(isRecordOf(isNumber)({ a: "a" }), false);
     assertEquals(isRecordOf(isString)({ a: true }), false);
   });
-  await testWithExamples(t, isRecordOf((_: unknown): _ is unknown => true), {
-    excludeExamples: ["record"],
-  });
+  await testWithExamples(
+    t,
+    isRecordOf((_: unknown): _ is unknown => true),
+    {
+      excludeExamples: ["record", "date", "promise", "set", "map"],
+    },
+  );
 });
 
 Deno.test("isRecordOf<T, K>", async (t) => {
@@ -482,9 +555,13 @@ Deno.test("isRecordOf<T, K>", async (t) => {
     assertEquals(isRecordOf(isString, isNumber)({ a: "a" }), false);
     assertEquals(isRecordOf(isBoolean, isNumber)({ a: true }), false);
   });
-  await testWithExamples(t, isRecordOf((_: unknown): _ is unknown => true), {
-    excludeExamples: ["record"],
-  });
+  await testWithExamples(
+    t,
+    isRecordOf((_: unknown): _ is unknown => true),
+    {
+      excludeExamples: ["record", "date", "promise", "set", "map"],
+    },
+  );
 });
 
 Deno.test("isRecordLikeOf<T>", async (t) => {


### PR DESCRIPTION
In unknownutil v3.16.0, we made slight adjustments to the behavior of `isRecord/isRecordOf` to be more strict. However, upon realizing that users did not expect such strictness in `isRecord/isRecordOf`, we introduced `isRecordLike/isRecordLikeOf` as an alternative.

However, acknowledging that the naming convention might not be very intuitive, we decided to roll back the changes to the behavior of `isRecord/isRecordOf` to its state in unknownutil v3.15, abandoning the strictness, and introduced a new, strictly enforced check called `isRecordObject/isRecordObjectOf`. As a result of this modification, `isRecordLike/isRecordLikeOf` has been deprecated.

While these changes are disruptive, they represent a shift towards greater flexibility and a return to the behavior of previous versions. Therefore, this is considered a minor release.

Close #65 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for improved type checking of record objects.
	- Enhanced support for additional types in object checking.
- **Refactor**
	- Renamed and updated several functions to clarify their purposes and improve logic for object type checking.
- **Tests**
	- Added and updated tests to cover the new and modified functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->